### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run biome:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run tsc
+
+  test-bun:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun-version: ["1.2.23", "1.3"]
+    env:
+      POSTGRES_DB: dev
+      POSTGRES_HOST: localhost
+      POSTGRES_PASSWORD: password
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: dev
+      FGA_API_URL: http://localhost:8080
+      PREFIX: tsfga
+      DATABASE_URL: postgres://dev:password@localhost:5432/dev
+    steps:
+      - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - run: docker compose up -d --wait
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run db:latest
+
+      - run: bun run turbo:test
+
+  test-node:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.x", "22.x", "24.x", "25.x"]
+    steps:
+      - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - run: node tests/smoke/smoke-test.mjs
+
+  test-deno:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: ["2.5.x", "2.6.x"]
+    steps:
+      - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - run: deno run --allow-all tests/smoke/smoke-test.mjs

--- a/tests/smoke/smoke-test.mjs
+++ b/tests/smoke/smoke-test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Runtime-agnostic smoke test for @tsfga/core.
+ *
+ * Validates that the built package can be imported and used from
+ * Node.js and Deno (ESM resolution via package.json exports).
+ *
+ * Run after `bun run build`:
+ *   node tests/smoke/smoke-test.mjs
+ *   deno run --allow-all tests/smoke/smoke-test.mjs
+ */
+
+import { createTsfga, check } from "../../packages/core/dist/index.js";
+
+// Verify exports are functions
+assert(typeof createTsfga === "function", "createTsfga should be a function");
+assert(typeof check === "function", "check should be a function");
+
+// Minimal mock store (only methods used by a simple direct-tuple check)
+const mockStore = {
+  findDirectTuple: async (_objectType, _objectId, _relation, _subjectType, _subjectId) => ({
+    objectType: "doc",
+    objectId: "1",
+    relation: "viewer",
+    subjectType: "user",
+    subjectId: "alice",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+  }),
+  findUsersetTuples: async () => [],
+  findTuplesByRelation: async () => [],
+  findRelationConfig: async () => null,
+  findConditionDefinition: async () => null,
+  insertTuple: async () => {},
+  deleteTuple: async () => false,
+  listCandidateObjectIds: async () => [],
+  listDirectSubjects: async () => [],
+  upsertRelationConfig: async () => {},
+  deleteRelationConfig: async () => false,
+  upsertConditionDefinition: async () => {},
+  deleteConditionDefinition: async () => false,
+};
+
+const client = createTsfga(mockStore);
+
+// Direct tuple match — should return true
+const allowed = await client.check({
+  objectType: "doc",
+  objectId: "1",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "alice",
+});
+assert(allowed === true, `expected true, got ${allowed}`);
+
+// No matching tuple — should return false
+const notAllowedStore = {
+  ...mockStore,
+  findDirectTuple: async () => null,
+};
+const notAllowedClient = createTsfga(notAllowedStore);
+const denied = await notAllowedClient.check({
+  objectType: "doc",
+  objectId: "1",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "bob",
+});
+assert(denied === false, `expected false, got ${denied}`);
+
+console.log("smoke test passed");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,15 @@
 {
   "$schema": "https://turborepo.dev/schema.v2.json",
+  "globalPassThroughEnv": [
+    "DATABASE_URL",
+    "FGA_API_URL",
+    "POSTGRES_DB",
+    "POSTGRES_HOST",
+    "POSTGRES_PASSWORD",
+    "POSTGRES_PORT",
+    "POSTGRES_USER",
+    "PREFIX"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Add a CI workflow that runs lint, type-checking, and tests
across multiple runtimes:

- lint: biome check
- typecheck: tsc --noEmit via turbo
- test-bun (1.2, 1.3): full test suite with PostgreSQL and
  OpenFGA via docker compose
- test-node (20, 22, 24, 25): ESM smoke test
- test-deno (2.5, 2.6): ESM smoke test

The smoke test imports the built @tsfga/core package, creates
a mock TupleStore, and runs basic check assertions to validate
ESM compatibility across runtimes.

Also adds globalPassThroughEnv to turbo.json so database and
infrastructure env vars reach child processes in CI (Turborepo
v2 strict mode filters them by default).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
