### PR TITLE
Run core tests on Node.js and Deno via bun:test shims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
 
       - run: node tests/smoke/smoke-test.mjs
 
+      - run: bun run turbo:test:node
+
   test-deno:
     runs-on: ubuntu-latest
     strategy:
@@ -123,3 +125,5 @@ jobs:
       - run: bun run build
 
       - run: deno run --allow-all tests/smoke/smoke-test.mjs
+
+      - run: bun run turbo:test:deno

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ bun run turbo:test                     # Run all tests (infra must be running)
 bun run turbo:test:core                # Unit tests only (no infra needed)
 bun run turbo:test:conformance         # Conformance tests (infra required)
 bun run turbo:test:kysely              # Adapter tests (infra required)
+bun run turbo:test:node                # Core tests on Node.js (no infra needed)
+bun run turbo:test:deno                # Core tests on Deno (no infra needed)
 bun run build                          # Build all packages
 bun run tsc                            # Type check all packages
 bun run biome:check                    # Lint + format check (Biome)

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
         "@changesets/cli": "2.29.8",
+        "tsx": "^4.21.0",
         "turbo": "2.8.9",
       },
     },
@@ -397,6 +398,8 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -585,6 +588,8 @@
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
@@ -642,6 +647,8 @@
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "turbo": ["turbo@2.8.9", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.9", "turbo-darwin-arm64": "2.8.9", "turbo-linux-64": "2.8.9", "turbo-linux-arm64": "2.8.9", "turbo-windows-64": "2.8.9", "turbo-windows-arm64": "2.8.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-G+Mq8VVQAlpz/0HTsxiNNk/xywaHGl+dk1oiBREgOEVCCDjXInDlONWUn5srRnC9s5tdHTFD1bx1N19eR4hI+g=="],
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
     "turbo:test:conformance": "turbo run test --filter=@tsfga/conformance",
     "turbo:test:core": "turbo run test --filter=@tsfga/core",
     "turbo:test:kysely": "turbo run test --filter=@tsfga/kysely",
+    "turbo:test:deno": "turbo run test:deno",
+    "turbo:test:node": "turbo run test:node",
     "version": "changeset version"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.2",
     "@changesets/cli": "2.29.8",
+    "tsx": "4.21.0",
     "turbo": "2.8.9"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "build": "tsup",
     "test": "bun test",
+    "test:node": "node --import tsx --import ../../tests/node/register.mjs --test tests/check.test.ts tests/conditions.test.ts",
+    "test:deno": "deno test --allow-all --config ../../tests/deno/deno.json tests/",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/core/tests/conditions.test.ts
+++ b/packages/core/tests/conditions.test.ts
@@ -88,7 +88,7 @@ describe("evaluateTupleCondition", () => {
   test("throws ConditionNotFoundError for missing condition", async () => {
     const store = new MockTupleStore();
     const tuple = makeTuple({ conditionName: "nonexistent" });
-    expect(evaluateTupleCondition(store, tuple)).rejects.toBeInstanceOf(
+    await expect(evaluateTupleCondition(store, tuple)).rejects.toBeInstanceOf(
       ConditionNotFoundError,
     );
   });
@@ -110,7 +110,7 @@ describe("evaluateTupleCondition", () => {
       expression: "x.nonexistent_method()",
       parameters: {},
     });
-    expect(
+    await expect(
       evaluateTupleCondition(store, tuple, { x: 42 }),
     ).rejects.toBeInstanceOf(ConditionEvaluationError);
   });

--- a/tests/deno/bun-test-shim.ts
+++ b/tests/deno/bun-test-shim.ts
@@ -1,0 +1,9 @@
+export { expect } from "jsr:@std/expect@1";
+export {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  test,
+} from "jsr:@std/testing@1/bdd";

--- a/tests/deno/deno.json
+++ b/tests/deno/deno.json
@@ -1,0 +1,7 @@
+{
+	"imports": {
+		"bun:test": "./bun-test-shim.ts",
+		"@marcbachmann/cel-js": "npm:@marcbachmann/cel-js"
+	},
+	"nodeModulesDir": "auto"
+}

--- a/tests/deno/deno.lock
+++ b/tests/deno/deno.lock
@@ -1,0 +1,48 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@^1.0.14": "1.0.18",
+    "jsr:@std/assert@^1.0.17": "1.0.18",
+    "jsr:@std/expect@1": "1.0.17",
+    "jsr:@std/internal@^1.0.10": "1.0.12",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/testing@1": "1.0.17",
+    "npm:@marcbachmann/cel-js@*": "7.5.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.18": {
+      "integrity": "270245e9c2c13b446286de475131dc688ca9abcd94fc5db41d43a219b34d1c78",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/expect@1.0.17": {
+      "integrity": "316b47dd65c33e3151344eb3267bf42efba17d1415425f07ed96185d67fc04d9",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.14",
+        "jsr:@std/internal@^1.0.10"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/testing@1.0.17": {
+      "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.17",
+        "jsr:@std/internal@^1.0.12"
+      ]
+    }
+  },
+  "npm": {
+    "@marcbachmann/cel-js@7.5.1": {
+      "integrity": "sha512-3X+TKpt/xyPsVSU3R2bVeZQCOW5L29y+EVDOmOp2xnyD7bifNM/UypBaqs2Z6oC075p+tKtjPUT1kUwnyY7cQg==",
+      "bin": true
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@marcbachmann/cel-js@*"
+    ]
+  }
+}

--- a/tests/node/bun-test-shim.mjs
+++ b/tests/node/bun-test-shim.mjs
@@ -1,0 +1,54 @@
+/**
+ * Compatibility shim that implements the bun:test API subset used by this
+ * project on top of node:test + node:assert/strict. Loaded via the custom
+ * ESM loader in loader.mjs so that test files importing "bun:test" resolve
+ * here when running under Node.js.
+ */
+
+import { strict as assert } from "node:assert";
+import { after, before, beforeEach, afterEach, describe, test } from "node:test";
+
+const beforeAll = before;
+const afterAll = after;
+
+function expect(actual) {
+  const matchers = {
+    toBe(expected) {
+      assert.strictEqual(actual, expected);
+    },
+    toBeNull() {
+      assert.strictEqual(actual, null);
+    },
+    toEqual(expected) {
+      assert.deepStrictEqual(actual, expected);
+    },
+    toHaveLength(n) {
+      assert.strictEqual(actual.length, n);
+    },
+    toBeTruthy() {
+      assert.ok(actual);
+    },
+    toBeInstanceOf(ctor) {
+      assert.ok(
+        actual instanceof ctor,
+        `Expected instance of ${ctor.name}, got ${actual?.constructor?.name}`,
+      );
+    },
+    not: {
+      toBeNull() {
+        assert.notStrictEqual(actual, null);
+      },
+      toBe(expected) {
+        assert.notStrictEqual(actual, expected);
+      },
+    },
+    rejects: {
+      async toBeInstanceOf(ctor) {
+        await assert.rejects(actual, (err) => err instanceof ctor);
+      },
+    },
+  };
+  return matchers;
+}
+
+export { describe, test, beforeEach, afterEach, beforeAll, afterAll, expect };

--- a/tests/node/loader.mjs
+++ b/tests/node/loader.mjs
@@ -1,0 +1,13 @@
+/**
+ * Node.js ESM resolve hook that intercepts "bun:test" imports and redirects
+ * them to the local compatibility shim.
+ */
+
+const shimUrl = new URL("./bun-test-shim.mjs", import.meta.url).href;
+
+export function resolve(specifier, context, nextResolve) {
+  if (specifier === "bun:test") {
+    return { url: shimUrl, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/tests/node/register.mjs
+++ b/tests/node/register.mjs
@@ -1,0 +1,9 @@
+/**
+ * Registration entry point for node --import. Registers the bun:test
+ * ESM loader for import redirection. TypeScript transpilation is handled
+ * separately via --import tsx in the node command.
+ */
+
+import { register } from "node:module";
+
+register("./loader.mjs", import.meta.url);

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,14 @@
       "dependsOn": ["^build"],
       "cache": false
     },
+    "test:node": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
+    "test:deno": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "db:latest": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

- Add bun:test compatibility shims so the same test files run unmodified on Node.js and Deno
- Node.js shim uses a custom ESM loader hook (`tests/node/`) with `node:test` + `node:assert`
- Deno shim uses an import map (`tests/deno/`) with `@std/testing/bdd` + `@std/expect`
- CI now runs core tests on 4 Node.js versions (20-25) and 2 Deno versions (2.5-2.6)
- Fixes two floating `.rejects.toBeInstanceOf()` promises in conditions.test.ts

## Test plan

- [x] `bun run turbo:test:core` — Bun tests pass
- [x] `bun run turbo:test:node` — Node.js tests pass
- [x] `bun run turbo:test:deno` — Deno tests pass
- [x] `bun run biome:check` — no lint/format regressions
- [x] `bun run tsc` — no type errors
- [x] CI passes on all 10 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)