### PR TITLE
Run kysely and conformance tests on Node.js and Deno

### DIFF
--- a/.claude/hooks/quality-checks.sh
+++ b/.claude/hooks/quality-checks.sh
@@ -5,4 +5,4 @@ cd "$CLAUDE_PROJECT_DIR"
 bun run biome:format
 bun run biome:check || exit 2
 bun run tsc || exit 2
-bun run test || exit 2
+bun run turbo:test || exit 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,15 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ["20.x", "22.x", "24.x", "25.x"]
+    env:
+      POSTGRES_DB: dev
+      POSTGRES_HOST: localhost
+      POSTGRES_PASSWORD: password
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: dev
+      FGA_API_URL: http://localhost:8080
+      PREFIX: tsfga
+      DATABASE_URL: postgres://dev:password@localhost:5432/dev
     steps:
       - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
@@ -93,9 +102,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - run: docker compose up -d --wait
+
       - run: bun install --frozen-lockfile
 
       - run: bun run build
+
+      - run: bun run db:latest
 
       - run: node tests/smoke/smoke-test.mjs
 
@@ -107,6 +120,15 @@ jobs:
       fail-fast: false
       matrix:
         deno-version: ["2.5.x", "2.6.x"]
+    env:
+      POSTGRES_DB: dev
+      POSTGRES_HOST: localhost
+      POSTGRES_PASSWORD: password
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: dev
+      FGA_API_URL: http://localhost:8080
+      PREFIX: tsfga
+      DATABASE_URL: postgres://dev:password@localhost:5432/dev
     steps:
       - uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
@@ -120,9 +142,13 @@ jobs:
         with:
           deno-version: ${{ matrix.deno-version }}
 
+      - run: docker compose up -d --wait
+
       - run: bun install --frozen-lockfile
 
       - run: bun run build
+
+      - run: bun run db:latest
 
       - run: deno run --allow-all tests/smoke/smoke-test.mjs
 

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -15,6 +15,8 @@
     "db:latest": "kysely migrate:latest",
     "db:rollback": "kysely migrate:rollback --all",
     "test": "bun test",
+    "test:node": "node --import tsx --import ../../tests/node/register.mjs --test tests/kysely-adapter.test.ts",
+    "test:deno": "deno test --no-check --allow-all --config ../../tests/deno/deno.json tests/",
     "tsc": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/tests/conformance/package.json
+++ b/tests/conformance/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "bun test"
+    "test": "bun test",
+    "test:node": "node --import tsx --import ../node/register.mjs --test *.test.ts",
+    "test:deno": "deno test --no-check --allow-all --config ../deno/deno.json ."
   },
   "devDependencies": {
     "@tsfga/core": "workspace:*",

--- a/tests/deno/bun-test-shim.ts
+++ b/tests/deno/bun-test-shim.ts
@@ -4,6 +4,16 @@ export {
   afterEach,
   beforeAll,
   beforeEach,
-  describe,
   test,
 } from "jsr:@std/testing@1/bdd";
+
+import { describe as _describe } from "jsr:@std/testing@1/bdd";
+
+/**
+ * Wraps describe to disable Deno's resource and op sanitizers.
+ * npm packages like pg open TCP connections that outlive individual
+ * test suites, triggering false-positive leak detection in Deno >= 2.6.
+ */
+export function describe(name: string, fn: () => void) {
+  return _describe(name, { sanitizeResources: false, sanitizeOps: false }, fn);
+}

--- a/tests/deno/deno.json
+++ b/tests/deno/deno.json
@@ -1,7 +1,14 @@
 {
 	"imports": {
 		"bun:test": "./bun-test-shim.ts",
-		"@marcbachmann/cel-js": "npm:@marcbachmann/cel-js"
+		"@marcbachmann/cel-js": "npm:@marcbachmann/cel-js",
+		"@tsfga/core": "../../packages/core/dist/index.js",
+		"@tsfga/kysely": "../../packages/kysely/dist/index.js",
+		"kysely": "npm:kysely",
+		"pg": "npm:pg",
+		"@openfga/sdk": "npm:@openfga/sdk",
+		"@openfga/syntax-transformer": "npm:@openfga/syntax-transformer",
+		"yaml": "npm:yaml"
 	},
 	"nodeModulesDir": "auto"
 }


### PR DESCRIPTION
Add test:node and test:deno scripts to @tsfga/kysely and
@tsfga/conformance so turbo auto-discovers them. The CI
test-node and test-deno jobs now start PostgreSQL + OpenFGA
via docker compose and run migrations before the test step.

The Deno import map gains mappings for kysely, pg, and the
workspace packages so Deno can resolve bare specifiers used
by the adapter and conformance test suites. Both packages
use --no-check because pg and kysely reference Node globals
(Buffer, process) that Deno's type checker rejects.

The bun:test shim's describe wrapper now disables Deno's
resource and op sanitizers, which otherwise flag the pg TCP
pool as a leak in Deno >= 2.6.

Also fixes the Claude Code quality hook to use turbo:test
(the root package.json has no bare "test" script).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
