### PR TITLE
Add /ship workflow command

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: ship
+description: Validate, commit, push, watch CI, rebase, and open PR.
+---
+
+# Ship
+
+Full workflow: validate locally, commit, push, watch CI, rebase against
+upstream/main, squash fixups, and open PR to emfga/tsfga.

--- a/.claude/skills/ship/command/ship.md
+++ b/.claude/skills/ship/command/ship.md
@@ -1,0 +1,126 @@
+---
+description: Validate, commit, push, watch CI, rebase, and open PR.
+allowed-tools: [Bash, Read, Grep, Glob, Edit, Write]
+---
+
+Run the full local-validate → commit → push → CI-watch → rebase → PR workflow.
+
+Use `$ARGUMENTS` for hints about the commit message or PR description.
+
+---
+
+## Phase 1 — Local Validation
+
+Run these steps sequentially. On any failure: fix the issue and restart
+Phase 1 from step 1.
+
+Before starting, check if infrastructure is running (needed for kysely and
+conformance tests):
+
+```
+docker ps --filter "name=postgres" --filter "name=openfga" --format "{{.Names}}"
+```
+
+If PostgreSQL or OpenFGA are not running, run `bun run infra:setup` first.
+
+1. `bun run biome:format` — fix formatting
+2. `bun run biome:check` — lint (may auto-fix; if it reports errors, fix them)
+3. `bun run tsc` — type check all packages
+4. `bun run turbo:test` — run all tests (core, kysely, conformance, node, deno)
+
+If any step fails, diagnose and fix the problem, then restart from step 1.
+Do NOT proceed to Phase 2 until all 4 steps pass cleanly.
+
+---
+
+## Phase 2 — Commit
+
+1. `git status` — see all changed/untracked files
+2. `git diff` — review unstaged changes
+3. `git log --oneline -5` — check recent commit message style
+4. Stage files by name (`git add <file1> <file2> ...`). Never use `git add -A`
+   or `git add .`.
+5. Commit following project conventions:
+   - 50-char imperative header, capital first letter, no conventional-commit
+     prefix
+   - Body explains WHY, wrapped at ~74 columns
+   - Use HEREDOC format for the message
+   - End with `Co-Authored-By: Claude <model> <noreply@anthropic.com>`
+   - If `$ARGUMENTS` contains commit message hints, incorporate them
+
+---
+
+## Phase 3 — Push + CI Watch
+
+1. Check if the current branch tracks a remote:
+   `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null`
+2. If no upstream tracking: `git push -u origin HEAD`
+   Otherwise: `git push`
+3. Watch CI: `gh run watch --exit-status`
+   This blocks until the workflow completes.
+4. On CI failure:
+   a. `gh run view --log-failed` to see what failed
+   b. Diagnose and fix the issue
+   c. Loop back to **Phase 1** (re-validate everything before committing
+      the fix)
+
+---
+
+## Phase 4 — Rebase + Clean Up
+
+1. `git fetch upstream`
+2. `git rebase upstream/main`
+   - If conflicts arise, resolve them, `git add` the resolved files,
+     and `git rebase --continue`.
+3. Examine commit history: `git log --oneline upstream/main..HEAD`
+4. Identify fixup commits — commits that only fix lint errors, CI failures,
+   typos, or other mechanical issues introduced during the iteration loop.
+   These should be squashed into the commit they repair.
+5. To squash fixups (since interactive rebase requires an editor Claude
+   cannot use):
+   a. Count meaningful commits: the ones that should survive as separate
+      commits in the PR
+   b. `git reset --soft upstream/main` to unstage all commits while
+      keeping changes in the working tree
+   c. Re-commit in logical groups, each with a proper message following
+      project conventions
+   d. If there is only one logical change, create a single commit
+6. `git push --force-with-lease`
+7. Watch CI again: `gh run watch --exit-status`
+   - On failure, fix and loop back to Phase 1
+
+---
+
+## Phase 5 — Open PR
+
+1. `gh pr create --repo emfga/tsfga --base main --title "..." --body "$(cat <<'EOF'
+   ## Summary
+   <1-3 bullet points>
+
+   ## Test plan
+   - [ ] ...
+
+   Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"`
+2. Use `$ARGUMENTS` for hints on title/description if provided.
+3. Return the PR URL.
+
+---
+
+## Error Recovery Reference
+
+| Situation | Action |
+|-----------|--------|
+| Format/lint failure | Fix, restart Phase 1 from step 1 |
+| Type error | Fix, restart Phase 1 from step 1 |
+| Test failure | Fix, restart Phase 1 from step 1 |
+| CI failure | `gh run view --log-failed`, fix, restart Phase 1 |
+| Rebase conflict | Resolve conflicts, `git rebase --continue` |
+| Push rejected (non-fast-forward) | `git pull --rebase`, then retry push |
+| Infrastructure not running | `bun run infra:setup`, then retry |
+| No upstream remote | `git remote add upstream git@github.com:emfga/tsfga.git` |
+
+<user-request>
+$ARGUMENTS
+</user-request>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -911,6 +911,14 @@ The shims cover: `describe`, `test`, `beforeEach`, `afterEach`,
 `toEqual`, `toHaveLength`, `toBeTruthy`, `toBeInstanceOf`, `not.toBeNull`,
 `not.toBe`, and `rejects.toBeInstanceOf`.
 
+### Workflow Commands
+
+The `/ship` command automates the full iteration loop from local
+validation through PR creation: format, lint, type check, test, commit,
+push, watch CI, rebase against `upstream/main`, squash fixups, and open
+PR to `emfga/tsfga`. Pass arguments for commit/PR hints:
+`/ship Add list_users support to the check algorithm`
+
 ## Configuration Files
 
 ### `turbo.json`
@@ -937,6 +945,13 @@ or project references — turbo handles dependency ordering).
 Shared lint/format config at root. Ignores `**/schema.ts` (generated) and
 `**/dist/**` (build output). Uses kebab-case filename convention.
 
+## Git Remotes
+
+- **origin** — `git@github.com:lemuelroberto/tsfga.git` (personal fork,
+  push feature branches here)
+- **upstream** — `git@github.com:emfga/tsfga.git` (canonical repo, PR
+  target, rebase against `upstream/main`)
+
 ## Git Commit Messages
 
 - **Never** use conventional commit format (`feat:`, `fix:`, `chore:`, etc.)
@@ -955,6 +970,13 @@ Shared lint/format config at root. Ignores `**/schema.ts` (generated) and
   future renames. Only reference sources that meaningfully informed
   the implementation — not every tangential link. Multiple sources
   use separate `Ref:` lines or a `Refs:` block.
+
+### Commit Hygiene Before PR
+
+Before opening a PR, squash fixup commits (lint fixes, CI fixes, typos)
+into the commit they repair. Keep logically distinct changes as separate
+commits. Use `git reset --soft upstream/main` + recommit to reshape
+history when interactive rebase is not available.
 
 ## Anti-Patterns (DO NOT)
 


### PR DESCRIPTION
## Summary

- Add a Claude Code `/ship` skill that orchestrates the full validate → commit → push → CI-watch → rebase → PR workflow
- Document the command, git remotes, and commit hygiene guidance in CLAUDE.md
- Clean up `.claude/settings.local.json` by replacing session-specific permissions with general wildcard patterns

## Test plan

- [x] `bun run biome:format` — no fixes needed
- [x] `bun run biome:check` — no issues
- [x] `bun run tsc` — type check passes
- [x] `bun run turbo:test` — 332 conformance tests + core + kysely all pass
- [x] CI passes on fork

Generated with [Claude Code](https://claude.com/claude-code)