### PR TITLE
Remove push trigger from CI workflow

### DIFF
--- a/.claude/skills/ship/command/ship.md
+++ b/.claude/skills/ship/command/ship.md
@@ -56,13 +56,20 @@ Do NOT proceed to Phase 2 until all 4 steps pass cleanly.
    `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null`
 2. If no upstream tracking: `git push -u origin HEAD`
    Otherwise: `git push`
-3. Watch CI: `gh run watch --exit-status`
-   This blocks until the workflow completes.
-4. On CI failure:
-   a. `gh run view --log-failed` to see what failed
+3. Trigger CI manually on origin:
+   `gh workflow run CI --repo <origin-owner>/tsfga --ref <branch>`
+   Get the origin owner from:
+   `gh repo view --json owner -q .owner.login`
+4. Wait a few seconds for the run to register, then find it:
+   `gh run list --workflow=CI --branch=<branch> --repo <origin-owner>/tsfga --limit 1 --json databaseId -q '.[0].databaseId'`
+5. Watch CI:
+   `gh run watch <run-id> --repo <origin-owner>/tsfga --exit-status`
+6. On CI failure:
+   a. `gh run view <run-id> --repo <origin-owner>/tsfga --log-failed`
+      to see what failed
    b. Diagnose and fix the issue
-   c. Loop back to **Phase 1** (re-validate everything before committing
-      the fix)
+   c. Loop back to **Phase 1** (re-validate everything before
+      committing the fix)
 
 ---
 
@@ -86,7 +93,9 @@ Do NOT proceed to Phase 2 until all 4 steps pass cleanly.
       project conventions
    d. If there is only one logical change, create a single commit
 6. `git push --force-with-lease`
-7. Watch CI again: `gh run watch --exit-status`
+7. Trigger CI manually on origin (same as Phase 3 steps 3-5):
+   `gh workflow run CI --repo <origin-owner>/tsfga --ref <branch>`
+   Then find the run and watch it with `gh run watch`.
    - On failure, fix and loop back to Phase 1
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -859,6 +859,20 @@ bun run version                          # Apply changesets to versions
 bun run release                          # Build + publish
 ```
 
+### CI Workflow (`.github/workflows/ci.yml`)
+
+Triggers: `pull_request` (main), `workflow_dispatch`.
+
+No `push` trigger — on upstream, `pull_request` covers PRs;
+on forks, the `/ship` command triggers CI manually via
+`gh workflow run`. This avoids duplicate runs on upstream
+and gives forks explicit control over CI.
+
+### Preview Workflow (`.github/workflows/preview.yml`)
+
+Publishes preview packages via `pkg-pr-new` on push and PR.
+Restricted to `emfga/tsfga` (`if: github.repository`).
+
 ### Releasing
 
 Each package is versioned independently. A manually triggered


### PR DESCRIPTION
## Summary

- Remove the `push` trigger from CI entirely, replacing it
  with `pull_request` (main) + `workflow_dispatch` only
- Delete the `should-run` gate job and all `needs` references
- On upstream, `pull_request` covers PRs; on forks, `/ship`
  triggers CI manually via `gh workflow run`
- Update `/ship` skill to trigger CI explicitly after push
  and after post-rebase force-push
- Document the new trigger policy in CLAUDE.md

## Behavior matrix

| Event | Repository | CI runs? |
|-------|-----------|----------|
| `pull_request` | `emfga/tsfga` | yes |
| `workflow_dispatch` | `emfga/tsfga` | yes |
| `workflow_dispatch` | fork | yes |
| `push` | anywhere | no |

## Test plan

- [x] Lint, typecheck, and core tests pass locally
- [ ] CI passes on upstream PR via `pull_request` event

Generated with [Claude Code](https://claude.com/claude-code)