### PR TITLE
Update bun.lock in bump script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -43,4 +43,13 @@ jq --arg v "$next" '.version = $v' \
   "$pkg_json" > "${pkg_json}.tmp"
 mv "${pkg_json}.tmp" "$pkg_json"
 
+lockfile="bun.lock"
+if [ -f "$lockfile" ]; then
+  dir_escaped="${dir//\//\\/}"
+  sed "/\"${dir_escaped}\": {/,/\"version\":/ {
+    s/\"version\": \"[^\"]*\"/\"version\": \"$next\"/
+  }" "$lockfile" > "${lockfile}.tmp"
+  mv "${lockfile}.tmp" "$lockfile"
+fi
+
 echo "${current} → ${next}"


### PR DESCRIPTION
## Summary
- The bump script updates `package.json` but leaves `bun.lock`
  out of sync, requiring a manual `bun install`
- Use `sed` to surgically update only the workspace's version
  field in `bun.lock`, avoiding a full `bun install` that could
  re-resolve transitive dependencies

## Test plan
- [x] Run `scripts/bump.sh packages/core patch` — confirmed
  both `packages/core/package.json` and `bun.lock` show the
  new version
- [x] `git diff` shows changes in both files and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)