### PR TITLE
Add README files for all packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1076,6 +1076,20 @@ history when interactive rebase is not available.
   and other content that becomes harder to maintain when broken
   across lines.
 
+## Package README files
+
+- Every package under `packages/*` and `tests/*` must
+  have a `README.md`
+- When creating a new package, include a README following
+  the structure of existing package READMEs
+- When making changes that affect a package's public API,
+  behavior, or usage, update its README to reflect those
+  changes
+- Package READMEs must mention the parent project and
+  link to the root README
+- Published packages must include installation and
+  quick-start sections
+
 ## References
 
 - OpenFGA docs: https://openfga.dev/docs/modeling/getting-started

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,92 @@
+# @tsfga/core
+
+OpenFGA-compatible relationship-based access control for
+TypeScript.
+
+Part of the [tsfga](../../README.md) monorepo.
+
+## Installation
+
+```bash
+npm install @tsfga/core
+```
+
+## Quick start
+
+```typescript
+import { createTsfga, type TupleStore } from "@tsfga/core";
+
+// Use any TupleStore implementation (e.g. @tsfga/kysely)
+const store: TupleStore = /* your store */;
+const fga = createTsfga(store);
+
+// Write a relation config
+await fga.writeRelationConfig({
+  objectType: "document",
+  relation: "viewer",
+  directlyAssignableTypes: ["user"],
+  allowsUsersetSubjects: false,
+});
+
+// Add a tuple
+await fga.addTuple({
+  objectType: "document",
+  objectId: "550e8400-e29b-41d4-a716-446655440000",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+});
+
+// Check access
+const allowed = await fga.check({
+  objectType: "document",
+  objectId: "550e8400-e29b-41d4-a716-446655440000",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+});
+// → true
+```
+
+## API
+
+`createTsfga(store, options?)` returns a `TsfgaClient`:
+
+| Method | Description |
+|---|---|
+| `check(request)` | Check if a subject has a relation on an object |
+| `addTuple(request)` | Insert or update a relationship tuple |
+| `removeTuple(request)` | Delete a relationship tuple |
+| `listObjects(objectType, relation, subjectType, subjectId)` | List object IDs the subject can access |
+| `listSubjects(objectType, objectId, relation)` | List direct subjects for an object + relation |
+| `writeRelationConfig(config)` | Insert or update a relation configuration |
+| `deleteRelationConfig(objectType, relation)` | Delete a relation configuration |
+| `writeConditionDefinition(condition)` | Insert or update a CEL condition definition |
+| `deleteConditionDefinition(name)` | Delete a CEL condition definition |
+
+## TupleStore interface
+
+The `TupleStore` interface is the extension point for custom
+database adapters. The core check algorithm depends only on
+this interface — it has no database dependencies.
+
+See
+[`src/store-interface.ts`](src/store-interface.ts)
+for the full interface definition.
+
+[`@tsfga/kysely`](../kysely/README.md) provides the included
+PostgreSQL adapter.
+
+## Conditions
+
+CEL condition evaluation is supported via
+[`@marcbachmann/cel-js`](https://github.com/nicholasgasior/cel-js).
+Tuples can reference named condition definitions, and the
+check algorithm evaluates them automatically.
+
+Context merge rule: tuple context properties take precedence
+over request context properties (matching OpenFGA behavior).
+
+## License
+
+MIT

--- a/packages/kysely/README.md
+++ b/packages/kysely/README.md
@@ -1,0 +1,74 @@
+# @tsfga/kysely
+
+Kysely/PostgreSQL adapter for
+[`@tsfga/core`](../core/README.md).
+
+Part of the [tsfga](../../README.md) monorepo. Implements
+the `TupleStore` interface from `@tsfga/core` using
+[Kysely](https://kysely.dev/) for PostgreSQL.
+
+## Installation
+
+```bash
+npm install @tsfga/kysely @tsfga/core kysely pg
+```
+
+## Quick start
+
+```typescript
+import { createTsfga } from "@tsfga/core";
+import { KyselyTupleStore } from "@tsfga/kysely";
+import { Kysely, PostgresDialect } from "kysely";
+import Pool from "pg-pool";
+
+const db = new Kysely({
+  dialect: new PostgresDialect({
+    pool: new Pool({ connectionString: "..." }),
+  }),
+});
+
+const store = new KyselyTupleStore(db);
+const fga = createTsfga(store);
+
+// Now use fga.check(), fga.addTuple(), etc.
+```
+
+## Migrations
+
+The package ships with Kysely migrations under
+`src/migrations/`. Apply them using `kysely-ctl` or
+programmatically:
+
+```typescript
+import { Migrator, FileMigrationProvider } from "kysely";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+const migrator = new Migrator({
+  db,
+  provider: new FileMigrationProvider({
+    fs,
+    path,
+    migrationFolder: path.join(
+      require.resolve("@tsfga/kysely"),
+      "../../src/migrations",
+    ),
+  }),
+});
+
+await migrator.migrateToLatest();
+```
+
+## Schema
+
+Migrations create a `tsfga` schema with three tables:
+
+| Table | Description |
+|---|---|
+| `tsfga.tuples` | Relationship tuples with optional conditions |
+| `tsfga.relation_configs` | Relation definitions (implied_by, computed_userset, etc.) |
+| `tsfga.condition_definitions` | Named CEL condition expressions |
+
+## License
+
+MIT

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -1,0 +1,76 @@
+# @tsfga/conformance
+
+Conformance tests that validate
+[`@tsfga/core`](../../packages/core/README.md) against a
+real OpenFGA service.
+
+Part of the [tsfga](../../README.md) monorepo. This package
+is private and not published to npm.
+
+## How it works
+
+Each test writes the same authorization model and tuples to
+both tsfga (via `KyselyTupleStore`) and OpenFGA (via
+`@openfga/sdk`), then asserts that `check()` returns
+identical results for every test case using
+`expectConformance()`.
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/) — runs PostgreSQL and
+  OpenFGA
+- Run `bun run infra:setup` from the repo root to start
+  services and apply migrations
+
+## Running
+
+```bash
+bun run turbo:test:conformance
+```
+
+## Test models
+
+**Basic patterns:**
+- `direct-access` — direct tuple assignment
+- `user-groups` — group membership
+- `roles-and-permissions` — RBAC with role hierarchy
+- `parent-child` — parent-child object relationships
+
+**Real-world models:**
+- `slack` — Slack workspace/channel permissions
+- `github` — GitHub org/repo/branch permissions
+- `gdrive` — Google Drive document sharing
+- `grafana` — Grafana dashboard access
+- `expenses` — expense approval workflows
+- `theopenlane.core` — TheOpenLane core model
+- `theopenlane.compliance` — TheOpenLane compliance
+- `theopenlane.programs` — TheOpenLane programs
+
+**Advanced patterns:**
+- `custom-roles` — dynamic custom role definitions
+- `public-access` — wildcard/public access
+- `blocklists` — exclusion-based access (but-not)
+- `entitlements` — feature entitlement checks
+- `advanced-entitlements` — multi-condition
+  entitlements
+
+**Conditions:**
+- `organization-context` — org-scoped conditions
+- `contextual-time-based` — time-window conditions
+- `temporal-access` — expiring access with timestamps
+- `multiple-restrictions` — intersection of multiple
+  conditions
+- `token-claims-contextual-tuples` — contextual tuples
+  with token claim conditions
+
+## Adding a new model
+
+1. Create a directory under `tests/conformance/` with a
+   `model.dsl` file (OpenFGA DSL) and a `tuples.yaml`
+   file (relationship tuples)
+2. Write a test file using `expectConformance()` — see
+   existing tests for the pattern
+3. Pick an unused UUID prefix for deterministic IDs (see
+   existing test files for allocated ranges)
+4. Run `bun run turbo:test:conformance` to verify both
+   tsfga and OpenFGA agree on all checks

--- a/tests/deno/README.md
+++ b/tests/deno/README.md
@@ -1,0 +1,54 @@
+# tests/deno
+
+`bun:test` compatibility shim for Deno.
+
+Part of the [tsfga](../../README.md) monorepo.
+
+## Purpose
+
+Test files in this project use `import from "bun:test"`
+exclusively. This directory provides a `deno.json` import
+map that remaps `"bun:test"` to a local shim built on
+`@std/testing/bdd` + `@std/expect`.
+
+This allows the same test files to run on Deno without
+modification.
+
+## How it works
+
+```
+import "bun:test"  →  import map  →  bun-test-shim.ts
+```
+
+- **`deno.json`** — import map that redirects `"bun:test"`
+  to the local shim; also maps npm dependencies and
+  enables `nodeModulesDir: "auto"` for resolution from
+  the existing `node_modules/`
+- **`bun-test-shim.ts`** — re-exports `@std/testing/bdd`
+  and `@std/expect` with a `describe` wrapper that
+  disables Deno's resource/op sanitizers (avoids
+  false-positive leak detection from npm packages like
+  `pg`)
+
+## Supported API
+
+`describe`, `test`, `beforeEach`, `afterEach`, `beforeAll`,
+`afterAll`, and `expect()` with matchers: `toBe`,
+`toBeNull`, `toEqual`, `toHaveLength`, `toBeTruthy`,
+`toBeInstanceOf`, `not.toBeNull`, `not.toBe`, and
+`rejects.toBeInstanceOf`.
+
+## Running
+
+From the repo root:
+
+```bash
+bun run turbo:test:deno
+```
+
+Or directly:
+
+```bash
+deno test --allow-all \
+  --config ../../tests/deno/deno.json tests/
+```

--- a/tests/node/README.md
+++ b/tests/node/README.md
@@ -1,0 +1,52 @@
+# tests/node
+
+`bun:test` compatibility shim for Node.js.
+
+Part of the [tsfga](../../README.md) monorepo.
+
+## Purpose
+
+Test files in this project use `import from "bun:test"`
+exclusively. This directory provides a custom ESM loader
+that intercepts `"bun:test"` imports and redirects them to
+a compatibility shim built on `node:test` + `node:assert`.
+
+This allows the same test files to run on Node.js without
+modification.
+
+## How it works
+
+```
+import "bun:test"  →  ESM loader hook  →  bun-test-shim.mjs
+```
+
+- **`register.mjs`** — entry point for `node --import`;
+  registers the ESM loader
+- **`loader.mjs`** — ESM resolve hook that redirects
+  `"bun:test"` to the local shim
+- **`bun-test-shim.mjs`** — implements the `bun:test` API
+  subset using `node:test` + `node:assert/strict`
+
+## Supported API
+
+`describe`, `test`, `beforeEach`, `afterEach`, `beforeAll`,
+`afterAll`, and `expect()` with matchers: `toBe`,
+`toBeNull`, `toEqual`, `toHaveLength`, `toBeTruthy`,
+`toBeInstanceOf`, `not.toBeNull`, `not.toBe`, and
+`rejects.toBeInstanceOf`.
+
+## Running
+
+From the repo root (requires `tsx` for TypeScript
+transpilation):
+
+```bash
+bun run turbo:test:node
+```
+
+Or directly:
+
+```bash
+node --import tsx --import ./tests/node/register.mjs \
+  --test 'packages/core/tests/*.test.ts'
+```

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,0 +1,39 @@
+# tests/smoke
+
+Runtime-agnostic smoke test for `@tsfga/core`.
+
+Part of the [tsfga](../../README.md) monorepo.
+
+## Purpose
+
+Validates that the built `@tsfga/core` package can be
+imported and used from Node.js and Deno via standard ESM
+resolution (package.json `exports`). This catches packaging
+issues (missing exports, broken build output) that unit
+tests running under Bun would not detect.
+
+## How it works
+
+`smoke-test.mjs` imports `createTsfga` and `check` from
+the built `dist/` output, creates a minimal mock
+`TupleStore`, and runs two basic checks:
+
+1. Direct tuple match returns `true`
+2. Missing tuple returns `false`
+
+The test uses plain `assert()` with no test framework
+dependency.
+
+## Running
+
+Build first, then run on either runtime:
+
+```bash
+bun run build
+
+# Node.js
+node tests/smoke/smoke-test.mjs
+
+# Deno
+deno run --allow-all tests/smoke/smoke-test.mjs
+```


### PR DESCRIPTION
## Summary

- Add READMEs for `@tsfga/core`, `@tsfga/kysely`, and
  `@tsfga/conformance` with installation, usage, and
  structure documentation
- Add READMEs for `tests/node/`, `tests/deno/`, and
  `tests/smoke/` explaining the cross-runtime shims and
  smoke test
- Add "Package README files" section to CLAUDE.md
  enforcing README maintenance going forward

## Test plan

- [x] `bun run biome:check` passes
- [x] `bun run tsc` passes
- [x] `bun run turbo:test:core` passes
- [x] CI passes (all jobs green)
- [x] Relative links between READMEs are valid paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)