### PR TITLE
Require manual approval for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":dependencyDashboardApproval",
     ":disableRateLimiting",
     ":docker",
     ":enableVulnerabilityAlerts",
@@ -15,5 +16,8 @@
   "commitMessageAction": "Bump",
   "commitMessageExtra": "",
   "commitMessageLowerCase": "never",
-  "commitMessageTopic": "{{depName}}"
+  "commitMessageTopic": "{{depName}}",
+  "vulnerabilityAlerts": {
+    "dependencyDashboardApproval": true
+  }
 }


### PR DESCRIPTION
## Summary
- Renovate no longer opens update PRs on its own: the
  `:dependencyDashboardApproval` preset lists available updates on the
  Dependency Dashboard issue, and a PR is only created when a maintainer
  ticks that update's checkbox.
- The same approval gate is applied to `vulnerabilityAlerts`, which
  would otherwise bypass the dashboard and still open PRs automatically.

## Test plan
- [x] `jq . renovate.json` — valid JSON
- [ ] After merge: confirm the Dependency Dashboard issue lists pending
      updates with approval checkboxes instead of opening PRs