### PR TITLE
Grant id-token at job level for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,13 @@ jobs:
     if: github.repository == 'emfga/tsfga'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Repeated at job level: the runner only injects
+    # ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN when the job
+    # itself carries id-token: write, and npm needs both
+    # to exchange an OIDC token for a publish token.
+    permissions:
+      contents: write
+      id-token: write
     env:
       POSTGRES_DB: dev
       POSTGRES_HOST: localhost
@@ -148,12 +155,38 @@ jobs:
             "${dir}/package.json" > "${dir}/package.tmp"
           mv "${dir}/package.tmp" "${dir}/package.json"
 
+      # npm skips the OIDC exchange silently (log.silly)
+      # when the id-token request variables are missing,
+      # then fails with a bare ENEEDAUTH that names the
+      # wrong cause. Check the preconditions up front.
+      - name: Verify Trusted Publishing preconditions
+        if: >-
+          inputs.publish
+          && steps.published.outputs.published == 'false'
+        run: |
+          echo "npm $(npm --version)"
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] \
+            || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error::OIDC id-token request variables are" \
+              "missing. npm cannot use Trusted Publishing and" \
+              "will fail with ENEEDAUTH. Check that the job has" \
+              "id-token: write."
+            exit 1
+          fi
+          echo "OIDC id-token endpoint is available."
+
+      # --loglevel verbose: every OIDC failure inside npm is
+      # logged below the default level, so a misconfigured
+      # trusted publisher would otherwise surface as ENEEDAUTH
+      # with no explanation.
       - name: Publish to npm
         if: >-
           inputs.publish
           && steps.published.outputs.published == 'false'
         working-directory: ${{ steps.pkg.outputs.dir }}
-        run: npm publish --provenance --access public
+        run: |
+          npm publish --provenance --access public \
+            --loglevel verbose
 
       - name: Revert workspace resolution
         if: >-

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -150,5 +150,16 @@ Actions workflow identity via Sigstore — no long-lived
 npm token needed. The `--provenance` flag adds attestation
 linking each package to its source repo and build.
 
+The `id-token: write` permission is declared on the job as
+well as the workflow: the runner injects
+`ACTIONS_ID_TOKEN_REQUEST_URL` and
+`ACTIONS_ID_TOKEN_REQUEST_TOKEN` based on the job's own
+permissions, and npm needs both. When they are absent npm
+skips the token exchange without logging anything at the
+default level and `npm publish` fails with `ENEEDAUTH`,
+which reads like a missing token rather than a missing
+permission. The "Verify Trusted Publishing preconditions"
+step exists to catch that case with a useful message.
+
 **Tag convention:** `@tsfga/core@0.3.0`,
 `@tsfga/kysely@0.3.0`.


### PR DESCRIPTION
The release workflow declared `id-token: write` only at the workflow
level. The runner injects `ACTIONS_ID_TOKEN_REQUEST_URL` and
`ACTIONS_ID_TOKEN_REQUEST_TOKEN` based on the permissions of the job
itself, so the publish step ran without them, npm skipped the Trusted
Publishing token exchange, and `npm publish` failed with `ENEEDAUTH`.

That error is misleading twice over: it names a missing login when the
real problem is a missing permission, and npm logs the skip at `silly`
level, so the run output holds no trace of the OIDC attempt. The only
visible clue was the 3 ms between the tarball notice and the failure —
too short for the two HTTP round trips a real exchange needs.

## Changes

- Declare `permissions: id-token: write` on the `release` job, not just
  the workflow.
- Add a preflight step that fails with the actual cause when the
  id-token request variables are absent.
- Publish with `--loglevel verbose` so a rejected exchange reports why,
  instead of collapsing into the same opaque `ENEEDAUTH`.
- Document both in `RELEASING.md`, so the duplicated permission is not
  tidied away later.

## Validation

`biome:check`, `tsc`, and `turbo:test:core` pass. The workflow change
itself can only be exercised by dispatching `Release` from `main` after
this merges.