### PR TITLE
Pin the npm used to publish to an explicit path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,18 @@ jobs:
       # Trusted Publishing (OIDC) needs npm >= 11.5.1. Pin an
       # exact version so the publish toolchain cannot change
       # between a validate run and the publish run.
-      - run: npm install -g npm@11.19.0
+      #
+      # Install into an explicit prefix and put that first on
+      # PATH rather than self-updating the global npm: where a
+      # bare "npm install -g npm" lands depends on the ambient
+      # prefix, and when it landed off-PATH the publish step
+      # silently kept using Node's bundled npm 10, which has no
+      # OIDC support at all.
+      - name: Install npm with Trusted Publishing support
+        run: |
+          npm install -g --prefix "${RUNNER_TEMP}/npm-cli" \
+            npm@11.19.0
+          echo "${RUNNER_TEMP}/npm-cli/bin" >> "$GITHUB_PATH"
 
       - run: bun install --frozen-lockfile
 
@@ -155,16 +166,28 @@ jobs:
             "${dir}/package.json" > "${dir}/package.tmp"
           mv "${dir}/package.tmp" "${dir}/package.json"
 
-      # npm skips the OIDC exchange silently (log.silly)
-      # when the id-token request variables are missing,
-      # then fails with a bare ENEEDAUTH that names the
-      # wrong cause. Check the preconditions up front.
+      # npm skips the OIDC exchange silently (log.silly) when
+      # it is too old or the id-token request variables are
+      # missing, then fails with a bare ENEEDAUTH that names
+      # the wrong cause. Check both preconditions up front.
       - name: Verify Trusted Publishing preconditions
         if: >-
           inputs.publish
           && steps.published.outputs.published == 'false'
         run: |
-          echo "npm $(npm --version)"
+          version=$(npm --version)
+          echo "npm ${version} at $(command -v npm)"
+          required=11.5.1
+          older=$(
+            printf '%s\n%s\n' "$required" "$version" \
+              | sort -V | head -n 1
+          )
+          if [ "$older" != "$required" ]; then
+            echo "::error::npm ${version} predates Trusted" \
+              "Publishing support (needs >= ${required}), so" \
+              "publish would fail with ENEEDAUTH."
+            exit 1
+          fi
           if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] \
             || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
             echo "::error::OIDC id-token request variables are" \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -161,5 +161,14 @@ which reads like a missing token rather than a missing
 permission. The "Verify Trusted Publishing preconditions"
 step exists to catch that case with a useful message.
 
+npm itself only learned Trusted Publishing in 11.5.1, and
+Node 22 still bundles npm 10, so the workflow installs a
+pinned npm into `$RUNNER_TEMP/npm-cli` and prepends it to
+`PATH`. Self-updating the global npm is not reliable here:
+it reports success while landing somewhere that is not the
+`npm` later steps resolve, and npm 10 skips the OIDC
+exchange with the same silent ENEEDAUTH. The preconditions
+step also asserts the version for that reason.
+
 **Tag convention:** `@tsfga/core@0.3.0`,
 `@tsfga/kysely@0.3.0`.


### PR DESCRIPTION
Follow-up to #55, which fixed a suspect that turned out to be innocent.

The release job upgraded npm with a bare `npm install -g npm@11.19.0`.
The step reported success, but the publish step kept resolving Node 22's
bundled **npm 10.9.4**, which predates Trusted Publishing entirely — it
never attempts the OIDC exchange, so `npm publish` failed with
`ENEEDAUTH` again.

The `--loglevel verbose` added in #55 is what exposed it:

```
npm info using npm@10.9.4
npm verbose stack Error: This command requires you to be logged in
```

And the preconditions step confirmed the id-token permission was never
the problem:

```
npm 10.9.4
OIDC id-token endpoint is available.
```

Where a global self-install lands depends on the ambient prefix. When it
lands off `PATH` the mismatch is invisible: npm prints `added 1 package`
either way, and the publish step names a missing login rather than a
missing toolchain.

## Changes

- Install the pinned npm into `$RUNNER_TEMP/npm-cli` and prepend it to
  `PATH`, so the publish step cannot silently resolve a different npm.
- Assert `npm >= 11.5.1` in the preconditions step, so a stale toolchain
  fails by name instead of as `ENEEDAUTH`.
- Record both in `RELEASING.md`.

## Validation

Verified on a scratch workflow on the fork, replicating the release
job's exact setup sequence:

```
PROBE npm 11.19.0 at /home/runner/work/_temp/npm-cli/bin/npm
PROBE accept
```

resolved correctly from a later step in a different working directory,
after `bun install`. `biome:check`, `tsc`, and `turbo:test:core` pass
locally.