### PR TITLE
Raise default maxDepth to 25 to match OpenFGA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ export interface CheckRequest {
 
 /** Options for the check algorithm */
 export interface CheckOptions {
-  /** Maximum recursion depth (default: 10) */
+  /** Maximum recursion depth (default: 25) */
   maxDepth?: number;
 }
 
@@ -428,7 +428,8 @@ export async function check(
 - Do NOT merge `impliedBy` and `computedUserset` into one concept; they are
   distinct OpenFGA features
 - The `depth` parameter is internal; it is not exposed in the public API
-- `maxDepth` defaults to 10 but is configurable via `CheckOptions`
+- `maxDepth` defaults to 25 (matching OpenFGA's
+  `OPENFGA_RESOLVE_NODE_LIMIT`) but is configurable via `CheckOptions`
 
 ## CEL Conditions (`packages/core/src/conditions.ts`)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,8 +67,10 @@ const allowed = await fga.check({
 ## Depth limits and cycles
 
 `check()` resolves relations recursively with a configurable
-recursion budget (`maxDepth`, default 10, via the second
-argument of `createTsfga`).
+recursion budget (`maxDepth`, default 25, via the second
+argument of `createTsfga`). The default matches OpenFGA's
+`OPENFGA_RESOLVE_NODE_LIMIT` (25), so both systems exhaust
+resolution at the same model depth.
 
 - When the budget is exhausted, or when the resolution path
   revisits a node it already contains (a cyclic model),

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -17,7 +17,7 @@ import type { CheckOptions, CheckRequest, RelationConfig } from "./types.ts";
  *
  * Error semantics:
  * - Throws DepthExceededError when the recursion budget
- *   (`options.maxDepth`, default 10) is exhausted or a cycle is
+ *   (`options.maxDepth`, default 25) is exhausted or a cycle is
  *   detected in the resolution path. Exhaustion is never converted
  *   to `false`: inside an exclusion or intersection branch that
  *   would fail open.
@@ -34,7 +34,7 @@ export async function check(
   request: CheckRequest,
   options: CheckOptions = {},
 ): Promise<boolean> {
-  const maxDepth = options.maxDepth ?? 10;
+  const maxDepth = options.maxDepth ?? 25;
 
   // Wrap store with contextual tuples for the whole request.
   // Contextual tuples must pass the same validation as addTuple.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,7 @@ export interface TsfgaClient {
    * Check whether a subject has a relation on an object.
    *
    * @throws DepthExceededError when the recursion budget
-   *   (`maxDepth`, default 10) is exhausted or a cycle is detected
+   *   (`maxDepth`, default 25) is exhausted or a cycle is detected
    *   in the resolution path. Exhaustion never resolves to `false`
    *   — a truncated exclusion branch must not grant access.
    * @throws RelationConfigNotFoundError, InvalidSubjectTypeError,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,7 +62,7 @@ export interface CheckRequest {
 
 /** Options for the check algorithm */
 export interface CheckOptions {
-  /** Maximum recursion depth (default: 10) */
+  /** Maximum recursion depth (default: 25) */
   maxDepth?: number;
 }
 

--- a/tests/conformance/theopenlane/setup.ts
+++ b/tests/conformance/theopenlane/setup.ts
@@ -2272,7 +2272,7 @@ export async function setupTheopenlane(): Promise<TheopenlaneSetup> {
   await beginTransaction(db);
 
   const store = new KyselyTupleStore(db);
-  const tsfgaClient = createTsfga(store, { maxDepth: 25 });
+  const tsfgaClient = createTsfga(store);
 
   for (const condDef of CONDITION_DEFS) {
     await tsfgaClient.writeConditionDefinition(condDef);


### PR DESCRIPTION
OpenFGA caps resolution depth via OPENFGA_RESOLVE_NODE_LIMIT,
which defaults to 25. Our previous default of 10 could throw
DepthExceededError on models a stock OpenFGA server resolves
fine, breaking conformance for deep models unless callers knew
to override the option. Aligning the default means both systems
exhaust resolution at the same model depth out of the box.

The theopenlane conformance setup no longer needs its explicit
maxDepth: 25 override, so drop it.

Ref: https://openfga.dev/docs/getting-started/setup-openfga/configuration
