### PR TITLE
Make host-side service ports configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy to .env and adjust as needed. Bun loads .env from the repo
+# root; packages/kysely/ and tests/conformance/ symlink to it.
+# Bun expands ${VAR} references, so derived values below follow
+# their source variables automatically.
+
+POSTGRES_DB=dev
+POSTGRES_HOST=localhost
+POSTGRES_PASSWORD=password
+POSTGRES_PORT=5432
+POSTGRES_USER=dev
+
+# Host-side port mappings for the OpenFGA container. Change these
+# when another local application already uses a port — container-
+# side ports stay fixed (8080, 8081, 3000, 2112).
+FGA_HTTP_PORT=8080
+FGA_GRPC_PORT=8081
+FGA_PLAYGROUND_PORT=3000
+FGA_METRICS_PORT=2112
+
+FGA_API_URL=http://localhost:${FGA_HTTP_PORT}
+PREFIX=tsfga
+DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ tsfga/
 ├── tsconfig.json                    references-only (whole-repo tsc)
 ├── biome.json                       shared lint/format
 ├── compose.yaml                     PostgreSQL + OpenFGA services
-├── .env                             environment variables
+├── .env.example                     environment variable template (copy to .env)
 └── CLAUDE.md
 ```
 
@@ -673,9 +673,9 @@ services:
       - OPENFGA_DATASTORE_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable&search_path=openfga
       - OPENFGA_PLAYGROUND_ENABLED=true
     ports:
-      - "8080:8080"
-      - "8081:8081"
-      - "3000:3000"
+      - ${FGA_HTTP_PORT:-8080}:8080
+      - ${FGA_GRPC_PORT:-8081}:8081
+      - ${FGA_PLAYGROUND_PORT:-3000}:3000
     healthcheck:
       test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=openfga:8081"]
       interval: 5s
@@ -688,15 +688,16 @@ uses the `tsfga` schema. They share the database but not schema.
 
 ### Environment (`.env`)
 
-```
-POSTGRES_DB=dev
-POSTGRES_HOST=localhost
-POSTGRES_PASSWORD=password
-POSTGRES_PORT=5432
-POSTGRES_USER=dev
-FGA_API_URL=http://localhost:8080
-PREFIX=tsfga
-```
+`.env` is gitignored; copy `.env.example` (the canonical,
+documented template — keep it up to date when adding variables)
+to `.env` and adjust locally.
+
+Host-side service ports are configurable so local dev never
+collides with other applications: `POSTGRES_PORT` and the
+`FGA_*_PORT` variables set only the host mapping — container-side
+ports stay fixed (5432, 8080, 8081, 3000, 2112). Bun expands
+`${VAR}` references inside `.env`, so `FGA_API_URL` follows
+`FGA_HTTP_PORT` automatically.
 
 All configuration comes from environment variables (loaded from `.env` by Bun).
 **Never hard-code default values** in `process.env` reads — use bare

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
       timeout: 10s
     image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     ports:
-      - ${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}
+      - ${POSTGRES_PORT:-5432}:5432
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/18/docker
@@ -38,7 +38,7 @@ services:
     container_name: ${PREFIX:-tsfga}-openfga-migrate
     environment:
       - OPENFGA_DATASTORE_ENGINE=postgres
-      - OPENFGA_DATASTORE_URI=postgres://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-password}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-dev}?sslmode=disable&search_path=openfga
+      - OPENFGA_DATASTORE_URI=postgres://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-password}@postgres:5432/${POSTGRES_DB:-dev}?sslmode=disable&search_path=openfga
     command: migrate
     networks:
       - default
@@ -52,16 +52,16 @@ services:
     command: run
     environment:
       - OPENFGA_DATASTORE_ENGINE=postgres
-      - OPENFGA_DATASTORE_URI=postgres://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-password}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-dev}?sslmode=disable&search_path=openfga
+      - OPENFGA_DATASTORE_URI=postgres://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-password}@postgres:5432/${POSTGRES_DB:-dev}?sslmode=disable&search_path=openfga
       - OPENFGA_DATASTORE_MAX_OPEN_CONNS=100 #see postgres container
       - OPENFGA_PLAYGROUND_ENABLED=true
     networks:
       - default
     ports:
-      - "8080:8080" #http
-      - "8081:8081" #grpc
-      - "3000:3000" #playground
-      - "2112:2112" #prometheus metrics
+      - ${FGA_HTTP_PORT:-8080}:8080 #http
+      - ${FGA_GRPC_PORT:-8081}:8081 #grpc
+      - ${FGA_PLAYGROUND_PORT:-3000}:3000 #playground
+      - ${FGA_METRICS_PORT:-2112}:2112 #prometheus metrics
     healthcheck:
       test:
         [


### PR DESCRIPTION
Fixed host port mappings in compose.yaml made local dev fail
whenever another application already used 8080, 8081, 3000, or
2112 — docker compose up aborts on the port bind. Introduce
FGA_HTTP_PORT, FGA_GRPC_PORT, FGA_PLAYGROUND_PORT, and
FGA_METRICS_PORT so each mapping can be moved via .env, keeping
the container-side ports fixed.

The postgres mapping had a related latent bug: it published
POSTGRES_PORT on both the host and container side, but the
container always listens on 5432, so any non-default value broke
both the host mapping and the OpenFGA datastore URI derived from
it. Host mapping is now POSTGRES_PORT:5432, and the datastore
URIs use the fixed internal postgres:5432.

Since .env is gitignored, add a tracked .env.example as the
canonical template (Bun expands the ${VAR} references, so
FGA_API_URL and DATABASE_URL follow the port variables), and
replace the inline .env listing in CLAUDE.md with a pointer to
it. Verified by bringing the stack up with every port moved to a
non-default value and running the full test suite against it.
