### PR TITLE
Cache relation configs within a check request

### DIFF
--- a/packages/core/src/caching-store.ts
+++ b/packages/core/src/caching-store.ts
@@ -1,0 +1,169 @@
+import type { TupleStore } from "./store-interface.ts";
+import type {
+  AddTupleRequest,
+  ConditionDefinition,
+  RelationConfig,
+  RemoveTupleRequest,
+  Tuple,
+} from "./types.ts";
+
+/**
+ * Wraps a TupleStore, memoizing relation configs and condition
+ * definitions. Both are static per authorization model but are
+ * re-fetched at every node of the recursive check, so a
+ * request-scoped cache removes most of those round-trips.
+ *
+ * The cache stores promises (not resolved values) so concurrent
+ * branches asking for the same key coalesce on one in-flight
+ * query. Misses (`null`) are cached too. Rejected promises are
+ * evicted so a transient store error is not pinned for the rest
+ * of the request: a later branch retries and the union-level
+ * "true beats sibling error" semantics keep working.
+ *
+ * Intended lifetime is a single check request: create one
+ * instance per top-level `check()` call and discard it. Writes
+ * through this wrapper invalidate the affected entry, but
+ * writes through the raw store while a check is in flight may
+ * not be observed by that check (accepted staleness non-goal).
+ *
+ * Configs are keyed by a nested map, never a joined string:
+ * tsfga does not restrict identifier charsets, so a joined
+ * `type:relation` key would collide for names containing ":".
+ */
+export class CachingTupleStore implements TupleStore {
+  private configCache = new Map<
+    string,
+    Map<string, Promise<RelationConfig | null>>
+  >();
+  private conditionCache = new Map<
+    string,
+    Promise<ConditionDefinition | null>
+  >();
+
+  constructor(private inner: TupleStore) {}
+
+  findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    let byRelation = this.configCache.get(objectType);
+    if (!byRelation) {
+      byRelation = new Map();
+      this.configCache.set(objectType, byRelation);
+    }
+    let cached = byRelation.get(relation);
+    if (!cached) {
+      cached = this.inner.findRelationConfig(objectType, relation);
+      byRelation.set(relation, cached);
+      this.evictOnRejection(cached, byRelation, relation);
+    }
+    return cached;
+  }
+
+  findConditionDefinition(name: string): Promise<ConditionDefinition | null> {
+    let cached = this.conditionCache.get(name);
+    if (!cached) {
+      cached = this.inner.findConditionDefinition(name);
+      this.conditionCache.set(name, cached);
+      this.evictOnRejection(cached, this.conditionCache, name);
+    }
+    return cached;
+  }
+
+  /**
+   * Drop a cache entry if its promise rejects, but only while it
+   * is still the stored entry (a concurrent retry may have
+   * replaced it). The `catch` chain is a side effect that
+   * swallows the rejection on its own derived promise; callers
+   * holding the original promise still observe the error.
+   */
+  private evictOnRejection<V>(
+    promise: Promise<V>,
+    cache: Map<string, Promise<V>>,
+    key: string,
+  ): void {
+    promise.catch(() => {
+      if (cache.get(key) === promise) {
+        cache.delete(key);
+      }
+    });
+  }
+
+  findDirectTuple(
+    objectType: string,
+    objectId: string,
+    relation: string,
+    subjectType: string,
+    subjectId: string,
+  ): Promise<Tuple | null> {
+    return this.inner.findDirectTuple(
+      objectType,
+      objectId,
+      relation,
+      subjectType,
+      subjectId,
+    );
+  }
+
+  findUsersetTuples(
+    objectType: string,
+    objectId: string,
+    relation: string,
+  ): Promise<Tuple[]> {
+    return this.inner.findUsersetTuples(objectType, objectId, relation);
+  }
+
+  findTuplesByRelation(
+    objectType: string,
+    objectId: string,
+    relation: string,
+  ): Promise<Tuple[]> {
+    return this.inner.findTuplesByRelation(objectType, objectId, relation);
+  }
+
+  insertTuple(tuple: AddTupleRequest): Promise<void> {
+    return this.inner.insertTuple(tuple);
+  }
+
+  deleteTuple(tuple: RemoveTupleRequest): Promise<boolean> {
+    return this.inner.deleteTuple(tuple);
+  }
+
+  listCandidateObjectIds(objectType: string): Promise<string[]> {
+    return this.inner.listCandidateObjectIds(objectType);
+  }
+
+  listDirectSubjects(
+    objectType: string,
+    objectId: string,
+    relation: string,
+  ): Promise<
+    Array<{
+      subjectType: string;
+      subjectId: string;
+      subjectRelation: string | null;
+    }>
+  > {
+    return this.inner.listDirectSubjects(objectType, objectId, relation);
+  }
+
+  upsertRelationConfig(config: RelationConfig): Promise<void> {
+    this.configCache.get(config.objectType)?.delete(config.relation);
+    return this.inner.upsertRelationConfig(config);
+  }
+
+  deleteRelationConfig(objectType: string, relation: string): Promise<boolean> {
+    this.configCache.get(objectType)?.delete(relation);
+    return this.inner.deleteRelationConfig(objectType, relation);
+  }
+
+  upsertConditionDefinition(condition: ConditionDefinition): Promise<void> {
+    this.conditionCache.delete(condition.name);
+    return this.inner.upsertConditionDefinition(condition);
+  }
+
+  deleteConditionDefinition(name: string): Promise<boolean> {
+    this.conditionCache.delete(name);
+    return this.inner.deleteConditionDefinition(name);
+  }
+}

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -1,3 +1,4 @@
+import { CachingTupleStore } from "./caching-store.ts";
 import { evaluateTupleCondition } from "./conditions.ts";
 import { ContextualTupleStore } from "./contextual-store.ts";
 import { DepthExceededError } from "./errors.ts";
@@ -36,14 +37,21 @@ export async function check(
 ): Promise<boolean> {
   const maxDepth = options.maxDepth ?? 25;
 
+  // Request-scoped cache for relation configs and condition
+  // definitions: static per model, but read at every node.
+  const cachingStore = new CachingTupleStore(store);
+
   // Wrap store with contextual tuples for the whole request.
   // Contextual tuples must pass the same validation as addTuple.
-  let effectiveStore = store;
+  let effectiveStore: TupleStore = cachingStore;
   if (request.contextualTuples?.length) {
     for (const tuple of request.contextualTuples) {
-      await validateTupleWrite(store, tuple);
+      await validateTupleWrite(cachingStore, tuple);
     }
-    effectiveStore = new ContextualTupleStore(store, request.contextualTuples);
+    effectiveStore = new ContextualTupleStore(
+      cachingStore,
+      request.contextualTuples,
+    );
   }
 
   return checkNode(effectiveStore, request, maxDepth, 0, new Set());

--- a/packages/core/tests/caching-store.test.ts
+++ b/packages/core/tests/caching-store.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { CachingTupleStore } from "../src/caching-store.ts";
+import { check } from "../src/check.ts";
+import type { RelationConfig, Tuple } from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+/**
+ * MockTupleStore whose findRelationConfig rejects the first
+ * `failures` calls, then behaves normally. Shares the source
+ * store's data arrays.
+ */
+class FlakyStore extends MockTupleStore {
+  configCalls = 0;
+  private failuresRemaining: number;
+
+  constructor(source: MockTupleStore, failures: number) {
+    super();
+    this.tuples = source.tuples;
+    this.relationConfigs = source.relationConfigs;
+    this.conditionDefinitions = source.conditionDefinitions;
+    this.failuresRemaining = failures;
+  }
+
+  override findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    this.configCalls++;
+    if (this.failuresRemaining > 0) {
+      this.failuresRemaining--;
+      return Promise.reject(new Error("transient store error"));
+    }
+    return super.findRelationConfig(objectType, relation);
+  }
+}
+
+describe("CachingTupleStore", () => {
+  let store: MockTupleStore;
+  let caching: CachingTupleStore;
+
+  beforeEach(() => {
+    store = new MockTupleStore();
+    caching = new CachingTupleStore(store);
+  });
+
+  test("memoizes findRelationConfig per objectType:relation", async () => {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "viewer" }),
+    );
+
+    const first = await caching.findRelationConfig("doc", "viewer");
+    const second = await caching.findRelationConfig("doc", "viewer");
+
+    expect(first).toEqual(second);
+    expect(store.counts.findRelationConfig).toBe(1);
+  });
+
+  test("caches null relation config results", async () => {
+    const first = await caching.findRelationConfig("doc", "missing");
+    const second = await caching.findRelationConfig("doc", "missing");
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(store.counts.findRelationConfig).toBe(1);
+  });
+
+  test("distinct keys are fetched separately", async () => {
+    await caching.findRelationConfig("doc", "viewer");
+    await caching.findRelationConfig("doc", "editor");
+    await caching.findRelationConfig("folder", "viewer");
+
+    expect(store.counts.findRelationConfig).toBe(3);
+  });
+
+  test("concurrent lookups coalesce on one in-flight query", async () => {
+    const [first, second] = await Promise.all([
+      caching.findRelationConfig("doc", "viewer"),
+      caching.findRelationConfig("doc", "viewer"),
+    ]);
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(store.counts.findRelationConfig).toBe(1);
+  });
+
+  test("memoizes findConditionDefinition by name", async () => {
+    store.conditionDefinitions.push({
+      name: "always",
+      expression: "x == 1",
+      parameters: { x: "int" },
+    });
+
+    const first = await caching.findConditionDefinition("always");
+    const second = await caching.findConditionDefinition("always");
+    const missing = await caching.findConditionDefinition("nope");
+    const missingAgain = await caching.findConditionDefinition("nope");
+
+    expect(first).toEqual(second);
+    expect(missing).toBeNull();
+    expect(missingAgain).toBeNull();
+    expect(store.counts.findConditionDefinition).toBe(2);
+  });
+
+  test("names containing ':' do not collide", async () => {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "a:viewer" }),
+      makeConfig({
+        objectType: "doc:a",
+        relation: "viewer",
+        impliedBy: ["owner"],
+      }),
+    );
+
+    const first = await caching.findRelationConfig("doc", "a:viewer");
+    const second = await caching.findRelationConfig("doc:a", "viewer");
+
+    expect(first?.objectType).toBe("doc");
+    expect(first?.impliedBy).toBeNull();
+    expect(second?.objectType).toBe("doc:a");
+    expect(second?.impliedBy).toEqual(["owner"]);
+    expect(store.counts.findRelationConfig).toBe(2);
+  });
+
+  test("a rejected lookup is evicted and retried", async () => {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "viewer" }),
+    );
+    const flaky = new FlakyStore(store, 1);
+    const flakyCaching = new CachingTupleStore(flaky);
+
+    await expect(
+      flakyCaching.findRelationConfig("doc", "viewer"),
+    ).rejects.toBeInstanceOf(Error);
+
+    const retried = await flakyCaching.findRelationConfig("doc", "viewer");
+
+    expect(retried?.objectType).toBe("doc");
+    expect(flaky.configCalls).toBe(2);
+  });
+
+  test("concurrent callers share one rejection, then retry", async () => {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "viewer" }),
+    );
+    const flaky = new FlakyStore(store, 1);
+    const flakyCaching = new CachingTupleStore(flaky);
+
+    const results = await Promise.allSettled([
+      flakyCaching.findRelationConfig("doc", "viewer"),
+      flakyCaching.findRelationConfig("doc", "viewer"),
+    ]);
+
+    expect(results[0].status).toBe("rejected");
+    expect(results[1].status).toBe("rejected");
+    expect(flaky.configCalls).toBe(1);
+
+    const retried = await flakyCaching.findRelationConfig("doc", "viewer");
+    expect(retried?.objectType).toBe("doc");
+    expect(flaky.configCalls).toBe(2);
+  });
+
+  test("writes through the wrapper invalidate the entry", async () => {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "viewer" }),
+    );
+
+    const before = await caching.findRelationConfig("doc", "viewer");
+    expect(before?.impliedBy).toBeNull();
+
+    await caching.upsertRelationConfig(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        impliedBy: ["owner"],
+      }),
+    );
+    const after = await caching.findRelationConfig("doc", "viewer");
+    expect(after?.impliedBy).toEqual(["owner"]);
+
+    await caching.deleteRelationConfig("doc", "viewer");
+    const deleted = await caching.findRelationConfig("doc", "viewer");
+    expect(deleted).toBeNull();
+
+    expect(store.counts.findRelationConfig).toBe(3);
+  });
+
+  test("condition writes through the wrapper invalidate", async () => {
+    store.conditionDefinitions.push({
+      name: "flagged",
+      expression: "x == 1",
+      parameters: { x: "int" },
+    });
+
+    const before = await caching.findConditionDefinition("flagged");
+    expect(before?.expression).toBe("x == 1");
+
+    await caching.upsertConditionDefinition({
+      name: "flagged",
+      expression: "x == 2",
+      parameters: { x: "int" },
+    });
+    const after = await caching.findConditionDefinition("flagged");
+    expect(after?.expression).toBe("x == 2");
+
+    expect(store.counts.findConditionDefinition).toBe(2);
+  });
+
+  test("tuple reads pass through uncached", async () => {
+    await caching.findDirectTuple("doc", "d1", "viewer", "user", "alice");
+    await caching.findDirectTuple("doc", "d1", "viewer", "user", "alice");
+
+    expect(store.counts.findDirectTuple).toBe(2);
+  });
+});
+
+describe("check() uses request-scoped config cache", () => {
+  let store: MockTupleStore;
+
+  beforeEach(() => {
+    store = new MockTupleStore();
+  });
+
+  test("N-branch userset fanout fetches each config once", async () => {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        allowsUsersetSubjects: true,
+      }),
+      makeConfig({
+        objectType: "team",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    for (let i = 0; i < 5; i++) {
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "d1",
+          relation: "viewer",
+          subjectType: "team",
+          subjectId: `t${i}`,
+          subjectRelation: "member",
+        }),
+      );
+    }
+    store.resetCounts();
+
+    const result = await check(store, {
+      objectType: "doc",
+      objectId: "d1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+    });
+
+    expect(result).toBe(false);
+    // 6 nodes (1 root + 5 teams) but only 2 distinct configs
+    expect(store.counts.findRelationConfig).toBe(2);
+  });
+
+  test("sequential checks do not share a cache", async () => {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.resetCounts();
+
+    const request = {
+      objectType: "doc",
+      objectId: "d1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+    };
+    await check(store, request);
+    await check(store, request);
+
+    // One fetch per top-level check: the cache dies with the
+    // request, so a config write between checks is observed.
+    expect(store.counts.findRelationConfig).toBe(2);
+  });
+
+  test("contextual-tuple validation shares the cache", async () => {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.resetCounts();
+
+    const result = await check(store, {
+      objectType: "doc",
+      objectId: "d1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+      contextualTuples: [
+        {
+          objectType: "doc",
+          objectId: "d1",
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: "alice",
+        },
+      ],
+    });
+
+    expect(result).toBe(true);
+    // Validation fetched doc.viewer; the check node reuses it.
+    expect(store.counts.findRelationConfig).toBe(1);
+  });
+
+  test("condition shared by many tuples is fetched once", async () => {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        allowsUsersetSubjects: true,
+      }),
+      makeConfig({
+        objectType: "team",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.conditionDefinitions.push({
+      name: "flagged",
+      expression: "x == 1",
+      parameters: { x: "int" },
+    });
+    for (let i = 0; i < 5; i++) {
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "d1",
+          relation: "viewer",
+          subjectType: "team",
+          subjectId: `t${i}`,
+          subjectRelation: "member",
+          conditionName: "flagged",
+        }),
+      );
+    }
+    store.resetCounts();
+
+    const result = await check(store, {
+      objectType: "doc",
+      objectId: "d1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+      context: { x: 1 },
+    });
+
+    expect(result).toBe(false);
+    // 5 conditional userset tuples, 1 definition fetch
+    expect(store.counts.findConditionDefinition).toBe(1);
+  });
+});

--- a/packages/core/tests/helpers/mock-store.ts
+++ b/packages/core/tests/helpers/mock-store.ts
@@ -16,6 +16,18 @@ export class MockTupleStore implements TupleStore {
   relationConfigs: RelationConfig[] = [];
   conditionDefinitions: ConditionDefinition[] = [];
 
+  /** Store-call counts per method name, for round-trip assertions. */
+  counts: Record<string, number> = {};
+
+  /** Reset all call counts (data is untouched). */
+  resetCounts(): void {
+    this.counts = {};
+  }
+
+  private tally(method: string): void {
+    this.counts[method] = (this.counts[method] ?? 0) + 1;
+  }
+
   async findDirectTuple(
     objectType: string,
     objectId: string,
@@ -23,6 +35,7 @@ export class MockTupleStore implements TupleStore {
     subjectType: string,
     subjectId: string,
   ): Promise<Tuple | null> {
+    this.tally("findDirectTuple");
     return (
       this.tuples.find(
         (t) =>
@@ -41,6 +54,7 @@ export class MockTupleStore implements TupleStore {
     objectId: string,
     relation: string,
   ): Promise<Tuple[]> {
+    this.tally("findUsersetTuples");
     return this.tuples.filter(
       (t) =>
         t.objectType === objectType &&
@@ -55,6 +69,7 @@ export class MockTupleStore implements TupleStore {
     objectId: string,
     relation: string,
   ): Promise<Tuple[]> {
+    this.tally("findTuplesByRelation");
     return this.tuples.filter(
       (t) =>
         t.objectType === objectType &&
@@ -67,6 +82,7 @@ export class MockTupleStore implements TupleStore {
     objectType: string,
     relation: string,
   ): Promise<RelationConfig | null> {
+    this.tally("findRelationConfig");
     return (
       this.relationConfigs.find(
         (c) => c.objectType === objectType && c.relation === relation,
@@ -77,10 +93,12 @@ export class MockTupleStore implements TupleStore {
   async findConditionDefinition(
     name: string,
   ): Promise<ConditionDefinition | null> {
+    this.tally("findConditionDefinition");
     return this.conditionDefinitions.find((c) => c.name === name) ?? null;
   }
 
   async insertTuple(tuple: AddTupleRequest): Promise<void> {
+    this.tally("insertTuple");
     const idx = this.tuples.findIndex(
       (t) =>
         t.objectType === tuple.objectType &&
@@ -108,6 +126,7 @@ export class MockTupleStore implements TupleStore {
   }
 
   async deleteTuple(tuple: RemoveTupleRequest): Promise<boolean> {
+    this.tally("deleteTuple");
     const idx = this.tuples.findIndex(
       (t) =>
         t.objectType === tuple.objectType &&
@@ -125,6 +144,7 @@ export class MockTupleStore implements TupleStore {
   }
 
   async listCandidateObjectIds(objectType: string): Promise<string[]> {
+    this.tally("listCandidateObjectIds");
     const ids = new Set<string>();
     for (const t of this.tuples) {
       if (t.objectType === objectType) {
@@ -145,6 +165,7 @@ export class MockTupleStore implements TupleStore {
       subjectRelation: string | null;
     }>
   > {
+    this.tally("listDirectSubjects");
     return this.tuples
       .filter(
         (t) =>
@@ -160,6 +181,7 @@ export class MockTupleStore implements TupleStore {
   }
 
   async upsertRelationConfig(config: RelationConfig): Promise<void> {
+    this.tally("upsertRelationConfig");
     const idx = this.relationConfigs.findIndex(
       (c) =>
         c.objectType === config.objectType && c.relation === config.relation,
@@ -175,6 +197,7 @@ export class MockTupleStore implements TupleStore {
     objectType: string,
     relation: string,
   ): Promise<boolean> {
+    this.tally("deleteRelationConfig");
     const idx = this.relationConfigs.findIndex(
       (c) => c.objectType === objectType && c.relation === relation,
     );
@@ -188,6 +211,7 @@ export class MockTupleStore implements TupleStore {
   async upsertConditionDefinition(
     condition: ConditionDefinition,
   ): Promise<void> {
+    this.tally("upsertConditionDefinition");
     const idx = this.conditionDefinitions.findIndex(
       (c) => c.name === condition.name,
     );
@@ -199,6 +223,7 @@ export class MockTupleStore implements TupleStore {
   }
 
   async deleteConditionDefinition(name: string): Promise<boolean> {
+    this.tally("deleteConditionDefinition");
     const idx = this.conditionDefinitions.findIndex((c) => c.name === name);
     if (idx >= 0) {
       this.conditionDefinitions.splice(idx, 1);


### PR DESCRIPTION
The recursive check re-fetches relation configs and condition
definitions at every resolution node, although both are static per
authorization model. On a wide userset fanout of 1000 branches this is
~1000 redundant round-trips per check — 25% of all store calls.

This adds `CachingTupleStore`, a request-scoped wrapper created once
per top-level `check()` call:

- Memoizes `findRelationConfig` (nested map keyed objectType then
  relation — a joined string key would collide for names containing
  `:`) and `findConditionDefinition` by name, including null results.
- Caches promises rather than resolved values, so concurrent branches
  asking for the same key coalesce on a single in-flight query.
- Evicts rejected promises so a transient store error is not pinned
  for the whole request: a later branch retries, preserving the
  union-level "true beats sibling error" semantics for flaky backends.
- Invalidates the affected entry on writes through the wrapper; all
  other methods pass through untouched.

The wrapper sits inside the contextual-tuple overlay so contextual
tuple validation shares the same cache. Lifetime is one check request:
a config write between two checks is always observed; writes through
the raw store while a check is in flight may not be (accepted
non-goal). The wrapper is intentionally not exported — no public API
change.

The mock store now counts calls per method so tests can assert
round-trip behavior directly; 7 new tests cover memoization, null
caching, coalescing, rejection eviction, write invalidation,
sequential-check cache isolation, and contextual validation sharing.

Benchmarked against PostgreSQL (pool 10): a 1000-branch userset fanout
drops from 4004 to 3005 store calls and its median wall time from
365 ms to 260 ms; a TTU fanout of 100 drops from 405 to 306 calls.
Conformance suite (335 tests) unchanged.