### PR TITLE
Single-wave node reads and OpenFGA error parity

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -84,10 +84,16 @@ resolution at the same model depth.
   branch that resolves `true` wins even if a sibling branch
   threw `DepthExceededError`. If no branch grants and at least
   one errored, the error propagates.
-- In exclusion (`excludedBy`) and intersection branches,
-  errors always propagate (fail closed). A definite `false`
-  base result still denies without waiting on the exclusion
-  branch's outcome.
+- Exclusion (`excludedBy`) and intersection branches fail
+  closed: an errored branch never counts as satisfied or as
+  not-excluded. A definitive deny still short-circuits past a
+  sibling error, matching OpenFGA — an intersection operand
+  resolving `false`, or an exclusion branch resolving `true`,
+  denies even when the other branch errored.
+- Condition evaluation with missing declared parameters is an
+  error (`ConditionEvaluationError`), not an unmet condition —
+  matching OpenFGA's check behavior. A silently-unmet
+  condition would fail open through an exclusion branch.
 
 ## Contextual tuples
 

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -4,7 +4,15 @@ import { ContextualTupleStore } from "./contextual-store.ts";
 import { DepthExceededError } from "./errors.ts";
 import type { TupleStore } from "./store-interface.ts";
 import { validateTupleWrite } from "./tuple-validation.ts";
-import type { CheckOptions, CheckRequest, RelationConfig } from "./types.ts";
+import type {
+  CheckOptions,
+  CheckRequest,
+  RelationConfig,
+  Tuple,
+} from "./types.ts";
+
+/** Results of the per-node tuple batch: direct, wildcard, userset. */
+type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
 
 /**
  * Recursive check algorithm with support for:
@@ -45,8 +53,18 @@ export async function check(
   // Contextual tuples must pass the same validation as addTuple.
   let effectiveStore: TupleStore = cachingStore;
   if (request.contextualTuples?.length) {
-    for (const tuple of request.contextualTuples) {
-      await validateTupleWrite(cachingStore, tuple);
+    // Validate all contextual tuples concurrently; surface the
+    // first failure in tuple order (not completion order) so the
+    // thrown error is deterministic.
+    const validations = await Promise.allSettled(
+      request.contextualTuples.map((tuple) =>
+        validateTupleWrite(cachingStore, tuple),
+      ),
+    );
+    for (const validation of validations) {
+      if (validation.status === "rejected") {
+        throw validation.reason;
+      }
     }
     effectiveStore = new ContextualTupleStore(
       cachingStore,
@@ -81,6 +99,14 @@ async function checkNode(
   const visited = new Set(path);
   visited.add(key);
 
+  // Speculatively start the tuple batch so it overlaps the config
+  // fetch: one round-trip wave per node instead of two. Some paths
+  // never await it (config error, or an intersection without a
+  // direct operand); the derived catch keeps such a rejection from
+  // going unhandled while awaiting callers still see the error.
+  const reads = readNodeTuples(store, request);
+  reads.catch(() => {});
+
   // Fetch relation config once for use across all steps
   const config = await store.findRelationConfig(
     request.objectType,
@@ -90,8 +116,16 @@ async function checkNode(
   // Base resolution: intersection replaces steps 1-5 when present
   const resolveBase = (): Promise<boolean> =>
     config?.intersection
-      ? checkIntersection(store, request, config, maxDepth, depth, visited)
-      : checkBase(store, request, config, maxDepth, depth, visited);
+      ? checkIntersection(
+          store,
+          request,
+          config,
+          reads,
+          maxDepth,
+          depth,
+          visited,
+        )
+      : checkBase(store, request, config, reads, maxDepth, depth, visited);
 
   // Exclusion applies on top of the base result — including on top
   // of intersection results. Errors in either branch fail closed:
@@ -126,18 +160,15 @@ async function checkNode(
 }
 
 /**
- * Base check: steps 1-5 without exclusion or intersection handling.
+ * Issue the three per-node tuple reads (direct probe, wildcard
+ * probe, userset scan) as one batch. Started at node entry so
+ * they overlap the relation-config fetch.
  */
-async function checkBase(
+function readNodeTuples(
   store: TupleStore,
   request: CheckRequest,
-  config: RelationConfig | null,
-  maxDepth: number,
-  depth: number,
-  path: ReadonlySet<string>,
-): Promise<boolean> {
-  // Batch initial reads: direct, wildcard, and userset tuples
-  const [directTuple, wildcardTuple, usersetTuples] = await Promise.all([
+): Promise<NodeReads> {
+  return Promise.all([
     store.findDirectTuple(
       request.objectType,
       request.objectId,
@@ -158,23 +189,48 @@ async function checkBase(
       request.relation,
     ),
   ]);
+}
 
-  // Step 1: Direct tuple fast path
-  if (directTuple) {
-    if (await evaluateTupleCondition(store, directTuple, request.context)) {
-      return true;
-    }
+/**
+ * Base check: steps 1-5 without exclusion or intersection handling.
+ */
+async function checkBase(
+  store: TupleStore,
+  request: CheckRequest,
+  config: RelationConfig | null,
+  reads: Promise<NodeReads>,
+  maxDepth: number,
+  depth: number,
+  path: ReadonlySet<string>,
+): Promise<boolean> {
+  const [directTuple, wildcardTuple, usersetTuples] = await reads;
+
+  // Steps 1/1b: an unconditioned direct or wildcard hit answers
+  // immediately, before any sub-check is launched
+  if (directTuple && !directTuple.conditionName) {
+    return true;
   }
-
-  // Step 1b: Wildcard fast path
-  if (wildcardTuple) {
-    if (await evaluateTupleCondition(store, wildcardTuple, request.context)) {
-      return true;
-    }
+  if (wildcardTuple && !wildcardTuple.conditionName) {
+    return true;
   }
 
   // Collect all sub-check handlers for concurrent resolution
   const handlers: Array<() => Promise<boolean>> = [];
+
+  // Conditioned direct/wildcard hits race as union branches so
+  // their condition evaluation (a possible condition-definition
+  // fetch) does not block the fanout below. Union semantics
+  // apply: a sibling `true` beats a condition error.
+  if (directTuple) {
+    handlers.push(() =>
+      evaluateTupleCondition(store, directTuple, request.context),
+    );
+  }
+  if (wildcardTuple) {
+    handlers.push(() =>
+      evaluateTupleCondition(store, wildcardTuple, request.context),
+    );
+  }
 
   // Step 2: Userset expansion handlers
   for (const userset of usersetTuples) {
@@ -283,6 +339,7 @@ async function checkIntersection(
   store: TupleStore,
   request: CheckRequest,
   config: RelationConfig,
+  reads: Promise<NodeReads>,
   maxDepth: number,
   depth: number,
   path: ReadonlySet<string>,
@@ -295,7 +352,7 @@ async function checkIntersection(
   for (const operand of operands) {
     if (operand.type === "direct") {
       handlers.push(() =>
-        checkBase(store, request, config, maxDepth, depth, path),
+        checkBase(store, request, config, reads, maxDepth, depth, path),
       );
     } else if (operand.type === "computedUserset") {
       handlers.push(() =>

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -34,6 +34,12 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  *   resolves `true` wins even if a sibling branch threw
  *   DepthExceededError. If no branch resolves `true` and at least
  *   one errored, the error propagates.
+ * - Exclusion and intersection fail closed — an errored branch
+ *   never counts as satisfied or as not-excluded — but a
+ *   definitive deny short-circuits past a sibling error, matching
+ *   OpenFGA: an intersection operand resolving `false`, or an
+ *   exclusion branch resolving `true`, denies even when the other
+ *   branch errored.
  * - Contextual tuples are validated against relation configs
  *   exactly like `addTuple` (RelationConfigNotFoundError,
  *   InvalidSubjectTypeError, UsersetNotAllowedError).
@@ -128,10 +134,12 @@ async function checkNode(
       : checkBase(store, request, config, reads, maxDepth, depth, visited);
 
   // Exclusion applies on top of the base result — including on top
-  // of intersection results. Errors in either branch fail closed:
-  // a definite base `false` denies regardless of the exclusion
-  // branch, but a base grant with an errored exclusion branch must
-  // propagate the error rather than grant.
+  // of intersection results. A definitive deny short-circuits past
+  // a sibling error, matching OpenFGA: a base `false` denies even
+  // when the exclusion branch errored, and a granted exclusion
+  // branch denies even when the base errored. Errors otherwise
+  // fail closed: a base grant with an errored exclusion branch
+  // propagates the error rather than granting.
   if (config?.excludedBy) {
     const excludedBy = config.excludedBy;
     const [baseResult, exclusionResult] = await Promise.allSettled([
@@ -144,6 +152,9 @@ async function checkNode(
         visited,
       ),
     ]);
+    if (exclusionResult.status === "fulfilled" && exclusionResult.value) {
+      return false;
+    }
     if (baseResult.status === "rejected") {
       throw baseResult.reason;
     }
@@ -153,7 +164,7 @@ async function checkNode(
     if (exclusionResult.status === "rejected") {
       throw exclusionResult.reason;
     }
-    return !exclusionResult.value;
+    return true;
   }
 
   return resolveBase();
@@ -452,9 +463,11 @@ async function resolveUnion(
 
 /**
  * Run handlers concurrently. Resolves false on first false
- * (short-circuit). Resolves true when all return true. Rejects on
- * first error (fail closed: an errored operand never counts as
- * satisfied).
+ * (short-circuit) — a definitive false wins even when a sibling
+ * operand errored, matching OpenFGA's intersection. Resolves true
+ * when all return true. When no operand resolves false and at
+ * least one errored, rejects with the first error (fail closed:
+ * an errored operand never counts as satisfied).
  */
 async function resolveIntersection(
   handlers: Array<() => Promise<boolean>>,
@@ -465,19 +478,36 @@ async function resolveIntersection(
 
   return new Promise((resolve, reject) => {
     let remaining = handlers.length;
+    let firstError: unknown;
+    let hasError = false;
+
+    const settleIfDone = () => {
+      remaining--;
+      if (remaining === 0) {
+        if (hasError) {
+          reject(firstError);
+        } else {
+          resolve(true);
+        }
+      }
+    };
+
     for (const handler of handlers) {
       handler().then(
         (result) => {
           if (!result) {
             resolve(false);
           } else {
-            remaining--;
-            if (remaining === 0) {
-              resolve(true);
-            }
+            settleIfDone();
           }
         },
-        (error) => reject(error),
+        (error) => {
+          if (!hasError) {
+            hasError = true;
+            firstError = error;
+          }
+          settleIfDone();
+        },
       );
     }
   });

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -1,4 +1,4 @@
-import { EvaluationError, type ParseResult, parse } from "@marcbachmann/cel-js";
+import { type ParseResult, parse } from "@marcbachmann/cel-js";
 import { ConditionEvaluationError, ConditionNotFoundError } from "./errors.ts";
 import type { TupleStore } from "./store-interface.ts";
 import type { ConditionParameterType, Tuple } from "./types.ts";
@@ -41,7 +41,10 @@ function coerceValue(
  * - The condition evaluates to true
  * Returns false if the condition evaluates to false.
  * Throws ConditionNotFoundError if conditionName references a missing definition.
- * Throws ConditionEvaluationError if CEL evaluation fails.
+ * Throws ConditionEvaluationError if a declared parameter is
+ * absent from the merged context or CEL evaluation fails —
+ * matching OpenFGA's check path, where missing parameters are an
+ * evaluation error, not an unmet condition.
  */
 export async function evaluateTupleCondition(
   store: TupleStore,
@@ -60,13 +63,28 @@ export async function evaluateTupleCondition(
   // Merge contexts: tuple context wins over request context
   const context = { ...requestContext, ...tuple.conditionContext };
 
+  // Every declared parameter must be present in the merged
+  // context. OpenFGA's check path rejects evaluation with missing
+  // parameters as an evaluation error rather than treating the
+  // condition as unmet — an unmet condition would fail open
+  // through an exclusion branch ("not excluded" grants).
+  const missing: string[] = [];
+
   // Coerce values based on declared parameter types
   if (condDef.parameters) {
     for (const [key, paramType] of Object.entries(condDef.parameters)) {
       if (key in context) {
         context[key] = coerceValue(context[key], paramType);
+      } else {
+        missing.push(key);
       }
     }
+  }
+  if (missing.length > 0) {
+    throw new ConditionEvaluationError(
+      condDef.name,
+      new Error(`missing context parameters: ${missing.join(", ")}`),
+    );
   }
 
   let compiled = exprCache.get(condDef.expression);
@@ -79,12 +97,6 @@ export async function evaluateTupleCondition(
     const result = compiled(context);
     return result === true;
   } catch (error) {
-    // When a condition parameter is missing, treat the condition as
-    // not satisfied (matching OpenFGA behavior where missing parameters
-    // result in {allowed: false}).
-    if (error instanceof EvaluationError && error.code === "unknown_variable") {
-      return false;
-    }
     throw new ConditionEvaluationError(condDef.name, error);
   }
 }

--- a/packages/core/tests/check-concurrency.test.ts
+++ b/packages/core/tests/check-concurrency.test.ts
@@ -1,0 +1,589 @@
+import { describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import {
+  ConditionNotFoundError,
+  DepthExceededError,
+  RelationConfigNotFoundError,
+} from "../src/errors.ts";
+import type { RelationConfig, Tuple } from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * MockTupleStore that holds every node read open for a few
+ * milliseconds and records the maximum number of simultaneously
+ * in-flight reads, so tests can assert reads overlap.
+ */
+class GatedStore extends MockTupleStore {
+  inflight = 0;
+  highWater = 0;
+
+  private async gate<T>(op: () => Promise<T>): Promise<T> {
+    this.inflight++;
+    this.highWater = Math.max(this.highWater, this.inflight);
+    await delay(10);
+    const result = await op();
+    this.inflight--;
+    return result;
+  }
+
+  override findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    return this.gate(() => super.findRelationConfig(objectType, relation));
+  }
+
+  override findDirectTuple(
+    objectType: string,
+    objectId: string,
+    relation: string,
+    subjectType: string,
+    subjectId: string,
+  ): Promise<Tuple | null> {
+    return this.gate(() =>
+      super.findDirectTuple(
+        objectType,
+        objectId,
+        relation,
+        subjectType,
+        subjectId,
+      ),
+    );
+  }
+
+  override findUsersetTuples(
+    objectType: string,
+    objectId: string,
+    relation: string,
+  ): Promise<Tuple[]> {
+    return this.gate(() =>
+      super.findUsersetTuples(objectType, objectId, relation),
+    );
+  }
+}
+
+/** Rejects the config read after the tuple reads have resolved. */
+class DelayedConfigErrorStore extends MockTupleStore {
+  override async findRelationConfig(
+    _objectType: string,
+    _relation: string,
+  ): Promise<RelationConfig | null> {
+    await delay(10);
+    throw new RelationConfigReadFailure("config read failed");
+  }
+}
+
+class RelationConfigReadFailure extends Error {}
+
+/**
+ * Delays config reads for the "slow" object type so a
+ * later-indexed validation failure completes first.
+ */
+class SlowConfigStore extends MockTupleStore {
+  configHighWater = 0;
+  private configInflight = 0;
+
+  override async findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    this.configInflight++;
+    this.configHighWater = Math.max(this.configHighWater, this.configInflight);
+    if (objectType === "slow") {
+      await delay(20);
+    }
+    const result = await super.findRelationConfig(objectType, relation);
+    this.configInflight--;
+    return result;
+  }
+}
+
+describe("single-wave node reads", () => {
+  test("config fetch and tuple reads are issued concurrently", async () => {
+    const store = new GatedStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+
+    const result = await check(store, {
+      objectType: "doc",
+      objectId: "1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+    });
+
+    expect(result).toBe(false);
+    // One node issues 4 reads (config, direct, wildcard, userset)
+    // in a single overlapping wave.
+    expect(store.highWater).toBe(4);
+  });
+
+  test("config-read error surfaces after tuple reads resolve", async () => {
+    const store = new DelayedConfigErrorStore();
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+
+    await expect(
+      check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).rejects.toBeInstanceOf(RelationConfigReadFailure);
+  });
+
+  test("unconditioned direct hit launches no sub-checks", async () => {
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        allowsUsersetSubjects: true,
+      }),
+      makeConfig({
+        objectType: "team",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+    for (let i = 0; i < 3; i++) {
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "team",
+          subjectId: `t${i}`,
+          subjectRelation: "member",
+        }),
+      );
+    }
+    store.resetCounts();
+
+    const result = await check(store, {
+      objectType: "doc",
+      objectId: "1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+    });
+
+    expect(result).toBe(true);
+    // Only the root node's probes; the 3 userset branches would
+    // each have added 2 more findDirectTuple calls.
+    expect(store.counts.findDirectTuple).toBe(2);
+    expect(store.counts.findUsersetTuples).toBe(1);
+  });
+
+  test("sibling grant wins over a direct-condition error", async () => {
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        allowsUsersetSubjects: true,
+      }),
+      makeConfig({
+        objectType: "team",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      // Direct hit whose condition definition does not exist.
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+        conditionName: "missing",
+      }),
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "team",
+        subjectId: "eng",
+        subjectRelation: "member",
+      }),
+      makeTuple({
+        objectType: "team",
+        objectId: "eng",
+        relation: "member",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+
+    expect(
+      await check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).toBe(true);
+  });
+
+  test("direct-condition error propagates when nothing grants", async () => {
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+        conditionName: "missing",
+      }),
+    );
+
+    await expect(
+      check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).rejects.toBeInstanceOf(ConditionNotFoundError);
+  });
+
+  test("conditioned direct hit races the full sibling fanout", async () => {
+    // Unlike an unconditioned hit, a conditioned one is a union
+    // branch: all sibling sub-checks launch concurrently. This
+    // matches OpenFGA, where checkDirectUserTuple always races
+    // the userset branches; breadth bounding comes later via
+    // maxBreadth (mirroring OPENFGA_RESOLVE_NODE_BREADTH_LIMIT).
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        allowsUsersetSubjects: true,
+      }),
+      makeConfig({
+        objectType: "team",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.conditionDefinitions.push({
+      name: "flagged",
+      expression: "x == 1",
+      parameters: { x: "int" },
+    });
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+        conditionName: "flagged",
+        conditionContext: { x: 1 },
+      }),
+    );
+    for (let i = 0; i < 3; i++) {
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "team",
+          subjectId: `t${i}`,
+          subjectRelation: "member",
+        }),
+      );
+    }
+    store.resetCounts();
+
+    const result = await check(store, {
+      objectType: "doc",
+      objectId: "1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+    });
+
+    expect(result).toBe(true);
+    // Root probes (2) plus 2 probes per launched userset branch.
+    expect(store.counts.findDirectTuple).toBe(8);
+  });
+
+  test("surfaced error follows completion order across branches", async () => {
+    // Two erroring branches, no grant: the faster error wins, as
+    // in OpenFGA's union (error identity is completion-ordered).
+    // Here the direct branch's condition lookup is slowed, so the
+    // sibling cycle error surfaces deterministically.
+    class SlowConditionStore extends MockTupleStore {
+      override async findConditionDefinition(name: string) {
+        await delay(20);
+        return super.findConditionDefinition(name);
+      }
+    }
+    const store = new SlowConditionStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        impliedBy: ["looper"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "looper",
+        impliedBy: ["viewer"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+        conditionName: "missing",
+      }),
+    );
+
+    await expect(
+      check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).rejects.toBeInstanceOf(DepthExceededError);
+  });
+
+  test("tuples sampled before a mid-request config swap deny", async () => {
+    // Accepted staleness: the tuple batch overlaps the config
+    // fetch, so a node can pair older tuples with a newer config
+    // and deny where strict config-then-tuples ordering granted.
+    // Fail-closed direction only — a grant read at time t implies
+    // the store granted at time t. OpenFGA cannot express this
+    // scenario at all: a request resolves against one immutable
+    // model snapshot, which mutable relation configs approximate
+    // via the request-scoped config cache.
+    class MigratingStore extends MockTupleStore {
+      override async findRelationConfig(
+        objectType: string,
+        relation: string,
+      ): Promise<RelationConfig | null> {
+        if (objectType === "doc" && relation === "viewer") {
+          // Atomic migration between the two samplings: grant
+          // alice directly, drop the implied path she relied on.
+          this.tuples.push(
+            makeTuple({
+              objectType: "doc",
+              objectId: "1",
+              relation: "viewer",
+              subjectType: "user",
+              subjectId: "alice",
+            }),
+          );
+          const config = this.relationConfigs.find(
+            (c) => c.objectType === "doc" && c.relation === "viewer",
+          );
+          if (config) {
+            config.impliedBy = null;
+          }
+        }
+        return super.findRelationConfig(objectType, relation);
+      }
+    }
+    const store = new MigratingStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+        impliedBy: ["editor"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "editor",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "editor",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+
+    // Every instantaneous snapshot grants alice, and the old
+    // config-then-tuples order returned true; the overlapping
+    // waves pair pre-migration tuples with the post-migration
+    // config and deny.
+    expect(
+      await check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("contextual-tuple validation concurrency", () => {
+  test("validation errors surface in tuple order", async () => {
+    const store = new SlowConfigStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "fast",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+
+    // Tuple 0 fails slowly (no config for type "slow"); tuple 1
+    // fails immediately (disallowed subject type). The first
+    // tuple's error must surface regardless of completion order.
+    await expect(
+      check(store, {
+        objectType: "fast",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+        contextualTuples: [
+          {
+            objectType: "slow",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+          },
+          {
+            objectType: "fast",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "robot",
+            subjectId: "r2d2",
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(RelationConfigNotFoundError);
+  });
+
+  test("validations run concurrently", async () => {
+    const store = new SlowConfigStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "slow",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+      makeConfig({
+        objectType: "slow",
+        relation: "editor",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+
+    const result = await check(store, {
+      objectType: "slow",
+      objectId: "1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+      contextualTuples: [
+        {
+          objectType: "slow",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: "alice",
+        },
+        {
+          objectType: "slow",
+          objectId: "1",
+          relation: "editor",
+          subjectType: "user",
+          subjectId: "alice",
+        },
+      ],
+    });
+
+    expect(result).toBe(true);
+    // Both validations' config reads were in flight together.
+    expect(store.configHighWater).toBe(2);
+  });
+});

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -1125,6 +1125,160 @@ describe("check algorithm", () => {
     });
   });
 
+  describe("Definitive deny beats sibling error (OpenFGA parity)", () => {
+    test("intersection: false operand overrides erroring operand", async () => {
+      // OpenFGA's intersection swallows errors when another
+      // operand is definitively false.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "can_view",
+          intersection: [
+            { type: "computedUserset", relation: "member" },
+            { type: "computedUserset", relation: "erring" },
+          ],
+          allowsUsersetSubjects: false,
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "erring",
+          impliedBy: ["erring"],
+        }),
+      );
+      // alice is not a member: false wins over the cycle error.
+      expect(
+        await check(store, {
+          objectType: "doc",
+          objectId: "1",
+          relation: "can_view",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      ).toBe(false);
+    });
+
+    test("intersection: true operand plus error still throws", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "can_view",
+          intersection: [
+            { type: "computedUserset", relation: "member" },
+            { type: "computedUserset", relation: "erring" },
+          ],
+          allowsUsersetSubjects: false,
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "erring",
+          impliedBy: ["erring"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "member",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+      // No operand is definitively false: fail closed on the error.
+      await expect(
+        check(store, {
+          objectType: "doc",
+          objectId: "1",
+          relation: "can_view",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      ).rejects.toBeInstanceOf(DepthExceededError);
+    });
+
+    test("exclusion: granted exclusion branch overrides base error", async () => {
+      // OpenFGA short-circuits to deny when the subtracted branch
+      // grants, even if the base errored.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          impliedBy: ["looper"],
+          excludedBy: "banned",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "looper",
+          impliedBy: ["viewer"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "banned",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+      // The base cycles (error) but alice is banned: deny.
+      expect(
+        await check(store, {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      ).toBe(false);
+    });
+
+    test("exclusion: base error with false exclusion still throws", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          impliedBy: ["looper"],
+          excludedBy: "banned",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "looper",
+          impliedBy: ["viewer"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      // alice is not banned: the base error must fail closed.
+      await expect(
+        check(store, {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      ).rejects.toBeInstanceOf(DepthExceededError);
+    });
+  });
+
   describe("Multi-entry tuple-to-userset", () => {
     beforeEach(() => {
       store.relationConfigs.push(

--- a/packages/core/tests/conditions.test.ts
+++ b/packages/core/tests/conditions.test.ts
@@ -85,7 +85,7 @@ describe("evaluateTupleCondition", () => {
     expect(await evaluateTupleCondition(store, tuple)).toBe(true);
   });
 
-  test("returns false when a condition parameter is missing", async () => {
+  test("throws when a condition parameter is missing", async () => {
     const store = new MockTupleStore();
     store.conditionDefinitions.push({
       name: "in_region",
@@ -93,13 +93,18 @@ describe("evaluateTupleCondition", () => {
       parameters: { region: "string" },
     });
     const tuple = makeTuple({ conditionName: "in_region" });
-    // No context at all: the referenced variable is absent, which
-    // must deny (OpenFGA returns {allowed: false}), not throw.
-    expect(await evaluateTupleCondition(store, tuple)).toBe(false);
-    expect(await evaluateTupleCondition(store, tuple, {})).toBe(false);
+    // Missing declared parameters are an evaluation ERROR, not an
+    // unmet condition: OpenFGA's check path errors, and a silent
+    // `false` would fail open through an exclusion branch.
+    await expect(evaluateTupleCondition(store, tuple)).rejects.toBeInstanceOf(
+      ConditionEvaluationError,
+    );
+    await expect(
+      evaluateTupleCondition(store, tuple, {}),
+    ).rejects.toBeInstanceOf(ConditionEvaluationError);
   });
 
-  test("returns false when one of several parameters is missing", async () => {
+  test("throws when one of several parameters is missing", async () => {
     const store = new MockTupleStore();
     store.conditionDefinitions.push({
       name: "region_and_tier",
@@ -107,9 +112,9 @@ describe("evaluateTupleCondition", () => {
       parameters: { region: "string", tier: "string" },
     });
     const tuple = makeTuple({ conditionName: "region_and_tier" });
-    expect(await evaluateTupleCondition(store, tuple, { region: "us" })).toBe(
-      false,
-    );
+    await expect(
+      evaluateTupleCondition(store, tuple, { region: "us" }),
+    ).rejects.toBeInstanceOf(ConditionEvaluationError);
   });
 
   test("throws ConditionNotFoundError for missing condition", async () => {

--- a/tests/conformance/condition-error-siblings.test.ts
+++ b/tests/conformance/condition-error-siblings.test.ts
@@ -1,0 +1,267 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  ConditionEvaluationError,
+  createTsfga,
+  type TsfgaClient,
+} from "@tsfga/core";
+import type { DB } from "@tsfga/kysely";
+import { KyselyTupleStore } from "@tsfga/kysely";
+import type { Kysely } from "kysely";
+import { expectConformance } from "./helpers/conformance.ts";
+import {
+  beginTransaction,
+  destroyDb,
+  getDb,
+  rollbackTransaction,
+} from "./helpers/db.ts";
+import {
+  fgaCheck,
+  fgaCreateStore,
+  fgaWriteModel,
+  fgaWriteTuples,
+} from "./helpers/openfga.ts";
+
+// Validates union error semantics against real OpenFGA: a direct
+// tuple whose condition evaluation FAILS (missing context
+// parameter) is one racing union branch, and a granting sibling
+// branch (team#member) must win over that error in both systems.
+// When nothing grants, both systems must surface an error.
+//
+// Ref: https://github.com/openfga/openfga/blob/e04bde9e/internal/graph/check.go
+// (union continues past branch errors looking for Allowed: true;
+// checkDirectUserTuple returns the condition-evaluation error)
+
+const uuidMap = new Map<string, string>([
+  ["anne", "00000000-0000-4000-c400-000000000001"],
+  ["bob", "00000000-0000-4000-c400-000000000002"],
+  ["carl", "00000000-0000-4000-c400-000000000003"],
+  ["eng", "00000000-0000-4000-c400-000000000004"],
+  ["1", "00000000-0000-4000-c400-000000000005"],
+  ["2", "00000000-0000-4000-c400-000000000006"],
+]);
+
+function uuid(name: string): string {
+  const id = uuidMap.get(name);
+  if (!id) throw new Error(`No UUID for ${name}`);
+  return id;
+}
+
+describe("Condition Error vs Sibling Grant Conformance", () => {
+  let db: Kysely<DB>;
+  let storeId: string;
+  let authorizationModelId: string;
+  let tsfgaClient: TsfgaClient;
+
+  beforeAll(async () => {
+    db = getDb();
+    await beginTransaction(db);
+
+    const store = new KyselyTupleStore(db);
+    tsfgaClient = createTsfga(store);
+
+    // === Condition definition ===
+    await tsfgaClient.writeConditionDefinition({
+      name: "valid_ip",
+      expression: 'user_ip == "192.168.0.1"',
+      parameters: { user_ip: "string" },
+    });
+
+    // === Relation configs ===
+    await tsfgaClient.writeRelationConfig({
+      objectType: "team",
+      relation: "member",
+      directlyAssignableTypes: ["user"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "viewer",
+      directlyAssignableTypes: ["user", "team"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: true,
+    });
+
+    // === Tuples ===
+
+    // anne: conditioned direct grant with no stored context, so a
+    // context-free check fails condition evaluation
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: uuid("anne"),
+      conditionName: "valid_ip",
+    });
+
+    // ...and a sibling grant path via team membership
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "viewer",
+      subjectType: "team",
+      subjectId: uuid("eng"),
+      subjectRelation: "member",
+    });
+    await tsfgaClient.addTuple({
+      objectType: "team",
+      objectId: uuid("eng"),
+      relation: "member",
+      subjectType: "user",
+      subjectId: uuid("anne"),
+    });
+    await tsfgaClient.addTuple({
+      objectType: "team",
+      objectId: uuid("eng"),
+      relation: "member",
+      subjectType: "user",
+      subjectId: uuid("bob"),
+    });
+
+    // carl: ONLY a conditioned grant on document:2
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("2"),
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: uuid("carl"),
+      conditionName: "valid_ip",
+    });
+
+    // Setup OpenFGA
+    storeId = await fgaCreateStore("condition-error-siblings-conformance");
+    authorizationModelId = await fgaWriteModel(
+      storeId,
+      "./condition-error-siblings/model.dsl",
+    );
+    await fgaWriteTuples(
+      storeId,
+      "./condition-error-siblings/tuples.yaml",
+      authorizationModelId,
+      uuidMap,
+    );
+  });
+
+  afterAll(async () => {
+    await rollbackTransaction(db);
+    await destroyDb();
+  });
+
+  test("1: sibling team grant beats anne's condition error", async () => {
+    // No context: anne's direct branch errors (missing user_ip),
+    // but the team#member branch grants — both systems say true.
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("anne"),
+      },
+      true,
+    );
+  });
+
+  test("2: anne's conditioned grant works with context", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("anne"),
+        context: { user_ip: "192.168.0.1" },
+      },
+      true,
+    );
+  });
+
+  test("3: bob is granted via the team alone", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("bob"),
+      },
+      true,
+    );
+  });
+
+  test("4: both systems error when nothing grants carl", async () => {
+    // No context and no sibling path: the condition error is the
+    // only outcome. tsfga throws; OpenFGA returns an error (the
+    // helper maps it to null).
+    await expect(
+      tsfgaClient.check({
+        objectType: "document",
+        objectId: uuid("2"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("carl"),
+      }),
+    ).rejects.toBeInstanceOf(ConditionEvaluationError);
+
+    const openFgaResult = await fgaCheck(storeId, authorizationModelId, {
+      objectType: "document",
+      objectId: uuid("2"),
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: uuid("carl"),
+    });
+    expect(openFgaResult).toBeNull();
+  });
+
+  test("5: carl's conditioned grant works with context", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("2"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("carl"),
+        context: { user_ip: "192.168.0.1" },
+      },
+      true,
+    );
+  });
+
+  test("6: wrong ip denies carl in both systems", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("2"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("carl"),
+        context: { user_ip: "10.0.0.1" },
+      },
+      false,
+    );
+  });
+});

--- a/tests/conformance/condition-error-siblings/model.dsl
+++ b/tests/conformance/condition-error-siblings/model.dsl
@@ -1,0 +1,16 @@
+model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define member: [user]
+
+type document
+  relations
+    define viewer: [user with valid_ip, team#member]
+
+condition valid_ip(user_ip: string) {
+  user_ip == "192.168.0.1"
+}

--- a/tests/conformance/condition-error-siblings/tuples.yaml
+++ b/tests/conformance/condition-error-siblings/tuples.yaml
@@ -1,0 +1,28 @@
+# anne holds a conditioned direct grant with NO stored context:
+# checks without request context fail condition evaluation
+- user: user:anne
+  relation: viewer
+  object: document:1
+  condition:
+    name: valid_ip
+
+# ...but anne is also a team member, and the team grants viewer
+- user: team:eng#member
+  relation: viewer
+  object: document:1
+- user: user:anne
+  relation: member
+  object: team:eng
+
+# bob is only a team member (no conditioned tuple)
+- user: user:bob
+  relation: member
+  object: team:eng
+
+# carl holds ONLY a conditioned grant on document:2 (no sibling
+# grant path exists there)
+- user: user:carl
+  relation: viewer
+  object: document:2
+  condition:
+    name: valid_ip


### PR DESCRIPTION
## Summary

Two changes to the check algorithm, developed together because
validating the first against upstream OpenFGA uncovered the second.

**Issue node reads in a single concurrent wave.** Each resolution
node previously awaited the relation config before issuing the
direct/wildcard/userset tuple batch — two serial round-trip waves
per node. The tuple batch now starts speculatively at node entry
and overlaps the config fetch. Conditioned direct/wildcard hits
race as union branches instead of blocking the fanout (mirroring
OpenFGA's `checkDirect`), unconditioned hits still short-circuit
before launching any sub-checks, and contextual tuples validate
concurrently with errors surfaced deterministically in tuple order.

On the bench (local PostgreSQL, pool 10): a 10-deep `implied_by`
chain drops from ~15 ms to ~6 ms median, TTU fanout of 100
improves ~25%, and per-check store-call counts on the bench shapes
are unchanged. Accepted costs are documented in the commit body
and pinned by tests (conditioned-hit fanout launch, speculative
reads on intersections without a direct operand, deny-direction
config/tuple skew under concurrent config migrations).

**Match OpenFGA error semantics in check.** Cross-checking against
the OpenFGA source and probing a running v1.18.2 surfaced three
divergences, all now fixed:

- Missing declared condition parameters returned `false` (unmet)
  instead of raising an error. That fails open through
  `excludedBy` — "not excluded" grants. Now throws
  `ConditionEvaluationError` naming the missing keys, as OpenFGA's
  check path does.
- Intersection rejected on the first operand error; OpenFGA lets a
  definitive `false` override sibling errors. The theopenlane
  fixtures hit this via `member and access`.
- Exclusion propagated a base error even when the subtracted
  branch definitively granted; OpenFGA short-circuits to deny.

All three preserve fail-closed behavior: an error never converts
into a grant — only definitive denials win past sibling errors.

## Testing

- New `check-concurrency.test.ts` (11 tests): wave-overlap
  high-water mark, config-error propagation, fast-path call
  counts, sibling-grant-over-condition-error, completion-ordered
  error identity, mid-request config-swap staleness, contextual
  validation ordering and concurrency.
- New "definitive deny beats sibling error" block in
  `check.test.ts` (4 tests) covering both intersection and
  exclusion, each with its fail-closed counterpart.
- New conformance suite `condition-error-siblings` (6 tests)
  validating the union/condition error semantics against a real
  OpenFGA, including the case where both systems must error.
- Full gates: biome, tsc, core 106/106 on Bun/Node/Deno, kysely
  adapter suite, conformance 341/341 from a real
  PostgreSQL + OpenFGA.

CI on the fork: https://github.com/lemuelroberto/tsfga/actions/runs/31068429256 (all jobs green).