### PR TITLE
Bound node fanout with a maxBreadth option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,8 @@ export interface CheckOptions {
   /**
    * Maximum branches of one resolution node evaluated
    * concurrently (default: Infinity). Mirrors OpenFGA's
-   * OPENFGA_RESOLVE_NODE_BREADTH_LIMIT. Must be >= 1.
+   * OPENFGA_RESOLVE_NODE_BREADTH_LIMIT. Integer >= 1 or
+   * Infinity.
    */
   maxBreadth?: number;
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,12 @@ export interface CheckRequest {
 export interface CheckOptions {
   /** Maximum recursion depth (default: 25) */
   maxDepth?: number;
+  /**
+   * Maximum branches of one resolution node evaluated
+   * concurrently (default: Infinity). Mirrors OpenFGA's
+   * OPENFGA_RESOLVE_NODE_BREADTH_LIMIT. Must be >= 1.
+   */
+  maxBreadth?: number;
 }
 
 /** Parameters for adding a tuple */

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -101,11 +101,14 @@ Branches of one resolution node are evaluated concurrently,
 bounded by `maxBreadth` (default `Infinity` — unbounded, via
 the same options object as `maxDepth`). The option mirrors
 OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. Bounding
-breadth only reorders work — answers never depend on it — but
-caps how many concurrent store reads a single wide node can
-issue (useful to avoid saturating a connection pool). Branches
-still queued when a node settles are never started. Values
-below 1 throw `TsfgaError`.
+breadth never changes the boolean result or whether a check
+errors — it caps how many concurrent store reads a single wide
+node can issue (useful to avoid saturating a connection pool).
+When several branches fail, which branch's error surfaces
+depends on completion order — the same nondeterminism OpenFGA
+has. Branches still queued when a node settles are never
+started. `maxBreadth` must be an integer >= 1 or `Infinity`;
+anything else throws `TsfgaError`.
 
 ## Contextual tuples
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -95,6 +95,18 @@ resolution at the same model depth.
   matching OpenFGA's check behavior. A silently-unmet
   condition would fail open through an exclusion branch.
 
+## Breadth limits
+
+Branches of one resolution node are evaluated concurrently,
+bounded by `maxBreadth` (default `Infinity` — unbounded, via
+the same options object as `maxDepth`). The option mirrors
+OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. Bounding
+breadth only reorders work — answers never depend on it — but
+caps how many concurrent store reads a single wide node can
+issue (useful to avoid saturating a connection pool). Branches
+still queued when a node settles are never started. Values
+below 1 throw `TsfgaError`.
+
 ## Contextual tuples
 
 Contextual tuples passed on a `CheckRequest` are validated

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -1,7 +1,7 @@
 import { CachingTupleStore } from "./caching-store.ts";
 import { evaluateTupleCondition } from "./conditions.ts";
 import { ContextualTupleStore } from "./contextual-store.ts";
-import { DepthExceededError } from "./errors.ts";
+import { DepthExceededError, TsfgaError } from "./errors.ts";
 import type { TupleStore } from "./store-interface.ts";
 import { validateTupleWrite } from "./tuple-validation.ts";
 import type {
@@ -43,6 +43,11 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  * - Contextual tuples are validated against relation configs
  *   exactly like `addTuple` (RelationConfigNotFoundError,
  *   InvalidSubjectTypeError, UsersetNotAllowedError).
+ *
+ * Concurrency: branches of one resolution node run concurrently,
+ * bounded by `options.maxBreadth` (default Infinity — unbounded),
+ * mirroring OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`.
+ * Breadth only reorders work; answers never depend on it.
  */
 export async function check(
   store: TupleStore,
@@ -50,6 +55,11 @@ export async function check(
   options: CheckOptions = {},
 ): Promise<boolean> {
   const maxDepth = options.maxDepth ?? 25;
+  const maxBreadth = options.maxBreadth ?? Number.POSITIVE_INFINITY;
+  // The negated comparison also rejects NaN, which `< 1` misses.
+  if (!(maxBreadth >= 1)) {
+    throw new TsfgaError(`maxBreadth must be at least 1, got ${maxBreadth}`);
+  }
 
   // Request-scoped cache for relation configs and condition
   // definitions: static per model, but read at every node.
@@ -78,7 +88,7 @@ export async function check(
     );
   }
 
-  return checkNode(effectiveStore, request, maxDepth, 0, new Set());
+  return checkNode(effectiveStore, request, maxDepth, maxBreadth, 0, new Set());
 }
 
 /**
@@ -91,6 +101,7 @@ async function checkNode(
   store: TupleStore,
   request: CheckRequest,
   maxDepth: number,
+  maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
 ): Promise<boolean> {
@@ -128,10 +139,20 @@ async function checkNode(
           config,
           reads,
           maxDepth,
+          maxBreadth,
           depth,
           visited,
         )
-      : checkBase(store, request, config, reads, maxDepth, depth, visited);
+      : checkBase(
+          store,
+          request,
+          config,
+          reads,
+          maxDepth,
+          maxBreadth,
+          depth,
+          visited,
+        );
 
   // Exclusion applies on top of the base result — including on top
   // of intersection results. A definitive deny short-circuits past
@@ -148,6 +169,7 @@ async function checkNode(
         store,
         { ...request, relation: excludedBy },
         maxDepth,
+        maxBreadth,
         depth + 1,
         visited,
       ),
@@ -211,6 +233,7 @@ async function checkBase(
   config: RelationConfig | null,
   reads: Promise<NodeReads>,
   maxDepth: number,
+  maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
 ): Promise<boolean> {
@@ -262,6 +285,7 @@ async function checkBase(
           context: request.context,
         },
         maxDepth,
+        maxBreadth,
         depth + 1,
         path,
       );
@@ -276,6 +300,7 @@ async function checkBase(
           store,
           { ...request, relation: impliedRelation },
           maxDepth,
+          maxBreadth,
           depth + 1,
           path,
         ),
@@ -291,6 +316,7 @@ async function checkBase(
         store,
         { ...request, relation: computedUserset },
         maxDepth,
+        maxBreadth,
         depth + 1,
         path,
       ),
@@ -329,6 +355,7 @@ async function checkBase(
                 context: request.context,
               },
               maxDepth,
+              maxBreadth,
               depth + 1,
               path,
             ),
@@ -336,11 +363,11 @@ async function checkBase(
         }
       }
 
-      return resolveUnion(ttuHandlers);
+      return resolveUnion(ttuHandlers, maxBreadth);
     });
   }
 
-  return resolveUnion(handlers);
+  return resolveUnion(handlers, maxBreadth);
 }
 
 /**
@@ -352,6 +379,7 @@ async function checkIntersection(
   config: RelationConfig,
   reads: Promise<NodeReads>,
   maxDepth: number,
+  maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
 ): Promise<boolean> {
@@ -363,7 +391,16 @@ async function checkIntersection(
   for (const operand of operands) {
     if (operand.type === "direct") {
       handlers.push(() =>
-        checkBase(store, request, config, reads, maxDepth, depth, path),
+        checkBase(
+          store,
+          request,
+          config,
+          reads,
+          maxDepth,
+          maxBreadth,
+          depth,
+          path,
+        ),
       );
     } else if (operand.type === "computedUserset") {
       handlers.push(() =>
@@ -371,6 +408,7 @@ async function checkIntersection(
           store,
           { ...request, relation: operand.relation },
           maxDepth,
+          maxBreadth,
           depth + 1,
           path,
         ),
@@ -397,118 +435,125 @@ async function checkIntersection(
                 context: request.context,
               },
               maxDepth,
+              maxBreadth,
               depth + 1,
               path,
             ),
           );
         }
-        return resolveUnion(ttuHandlers);
+        return resolveUnion(ttuHandlers, maxBreadth);
       });
     }
   }
 
-  return resolveIntersection(handlers);
+  return resolveIntersection(handlers, maxBreadth);
 }
 
 /**
- * Run handlers concurrently. Resolves true on first true
- * (short-circuit). A `true` result wins even when sibling branches
+ * Run handlers with at most `maxBreadth` in flight, short-circuit
+ * on first true. A `true` result wins even when sibling branches
  * rejected (e.g. with DepthExceededError). When no handler resolves
  * true, rejects with the first error if any handler rejected;
- * resolves false otherwise.
+ * resolves false otherwise. Handlers still queued when the union
+ * settles are never started.
  */
-async function resolveUnion(
+function resolveUnion(
   handlers: Array<() => Promise<boolean>>,
+  maxBreadth: number,
 ): Promise<boolean> {
-  if (handlers.length === 0) {
-    return false;
-  }
-
-  return new Promise((resolve, reject) => {
-    let remaining = handlers.length;
-    let firstError: unknown;
-    let hasError = false;
-
-    const settleIfDone = () => {
-      remaining--;
-      if (remaining === 0) {
-        if (hasError) {
-          reject(firstError);
-        } else {
-          resolve(false);
-        }
-      }
-    };
-
-    for (const handler of handlers) {
-      handler().then(
-        (result) => {
-          if (result) {
-            resolve(true);
-          } else {
-            settleIfDone();
-          }
-        },
-        (error) => {
-          if (!hasError) {
-            hasError = true;
-            firstError = error;
-          }
-          settleIfDone();
-        },
-      );
-    }
-  });
+  return resolveShortCircuit(handlers, maxBreadth, true);
 }
 
 /**
- * Run handlers concurrently. Resolves false on first false
- * (short-circuit) — a definitive false wins even when a sibling
+ * Run handlers with at most `maxBreadth` in flight, short-circuit
+ * on first false — a definitive false wins even when a sibling
  * operand errored, matching OpenFGA's intersection. Resolves true
  * when all return true. When no operand resolves false and at
  * least one errored, rejects with the first error (fail closed:
- * an errored operand never counts as satisfied).
+ * an errored operand never counts as satisfied). Handlers still
+ * queued when the intersection settles are never started.
  */
-async function resolveIntersection(
+function resolveIntersection(
   handlers: Array<() => Promise<boolean>>,
+  maxBreadth: number,
+): Promise<boolean> {
+  return resolveShortCircuit(handlers, maxBreadth, false);
+}
+
+/**
+ * Bounded pull-model combinator shared by union and intersection —
+ * duals of each other: union short-circuits on `true` and resolves
+ * `false` on exhaustion; intersection short-circuits on `false`
+ * and resolves `true` on exhaustion. Mirrors OpenFGA's reducers,
+ * which take the breadth limit as their concurrency bound.
+ *
+ * Handlers launch in array order while fewer than `maxBreadth` are
+ * in flight; each settlement pulls the next queued handler. Once
+ * the result is decided nothing new starts, in-flight losers are
+ * ignored on completion, and their rejections are consumed by the
+ * callbacks attached at launch — no unhandled rejections. On
+ * exhaustion with no decisive result, the first-recorded error
+ * (by completion order, matching OpenFGA) propagates; otherwise
+ * the non-short-circuit value resolves.
+ */
+function resolveShortCircuit(
+  handlers: Array<() => Promise<boolean>>,
+  maxBreadth: number,
+  shortCircuitOn: boolean,
 ): Promise<boolean> {
   if (handlers.length === 0) {
-    return true;
+    return Promise.resolve(!shortCircuitOn);
   }
 
   return new Promise((resolve, reject) => {
-    let remaining = handlers.length;
+    let next = 0;
+    let active = 0;
+    let settled = false;
     let firstError: unknown;
     let hasError = false;
 
-    const settleIfDone = () => {
-      remaining--;
-      if (remaining === 0) {
+    const onHandlerDone = () => {
+      active--;
+      if (next < handlers.length) {
+        launch();
+      } else if (active === 0) {
+        settled = true;
         if (hasError) {
           reject(firstError);
         } else {
-          resolve(true);
+          resolve(!shortCircuitOn);
         }
       }
     };
 
-    for (const handler of handlers) {
-      handler().then(
-        (result) => {
-          if (!result) {
-            resolve(false);
-          } else {
-            settleIfDone();
-          }
-        },
-        (error) => {
-          if (!hasError) {
-            hasError = true;
-            firstError = error;
-          }
-          settleIfDone();
-        },
-      );
-    }
+    const launch = () => {
+      while (!settled && active < maxBreadth && next < handlers.length) {
+        const handler = handlers[next];
+        next++;
+        if (!handler) continue;
+        active++;
+        handler().then(
+          (result) => {
+            if (settled) return;
+            if (result === shortCircuitOn) {
+              settled = true;
+              resolve(shortCircuitOn);
+              return;
+            }
+            onHandlerDone();
+          },
+          (error) => {
+            if (settled) return;
+            if (!hasError) {
+              hasError = true;
+              firstError = error;
+            }
+            onHandlerDone();
+          },
+        );
+      }
+    };
+
+    launch();
   });
 }

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -47,7 +47,10 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  * Concurrency: branches of one resolution node run concurrently,
  * bounded by `options.maxBreadth` (default Infinity — unbounded),
  * mirroring OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`.
- * Breadth only reorders work; answers never depend on it.
+ * Breadth never changes the boolean result or whether a check
+ * resolves versus rejects; when several branches fail, which
+ * branch's error surfaces depends on completion order — the same
+ * nondeterminism OpenFGA has.
  */
 export async function check(
   store: TupleStore,
@@ -57,8 +60,16 @@ export async function check(
   const maxDepth = options.maxDepth ?? 25;
   const maxBreadth = options.maxBreadth ?? Number.POSITIVE_INFINITY;
   // The negated comparison also rejects NaN, which `< 1` misses.
-  if (!(maxBreadth >= 1)) {
-    throw new TsfgaError(`maxBreadth must be at least 1, got ${maxBreadth}`);
+  // Fractional values would admit one more branch than stated
+  // (`active < 1.5` allows 2 in flight), so only integers — and
+  // Infinity, which Number.isInteger rejects — are accepted.
+  if (
+    !(maxBreadth >= 1) ||
+    (maxBreadth !== Number.POSITIVE_INFINITY && !Number.isInteger(maxBreadth))
+  ) {
+    throw new TsfgaError(
+      `maxBreadth must be a positive integer or Infinity, got ${maxBreadth}`,
+    );
   }
 
   // Request-scoped cache for relation configs and condition
@@ -384,7 +395,16 @@ async function checkIntersection(
   path: ReadonlySet<string>,
 ): Promise<boolean> {
   const operands = config.intersection;
-  if (!operands) return true;
+  // An intersection with no operands would resolve vacuously true,
+  // granting access to every subject on a malformed config.
+  // OpenFGA's typesystem rejects set operations with too few
+  // children as an invalid model; fail closed with an error.
+  if (!operands || operands.length === 0) {
+    throw new TsfgaError(
+      `intersection for ${request.objectType}.${request.relation} ` +
+        "has no operands",
+    );
+  }
 
   const handlers: Array<() => Promise<boolean>> = [];
 
@@ -492,19 +512,20 @@ function resolveIntersection(
  * the result is decided nothing new starts, in-flight losers are
  * ignored on completion, and their rejections are consumed by the
  * callbacks attached at launch — no unhandled rejections. On
- * exhaustion with no decisive result, the first-recorded error
- * (by completion order, matching OpenFGA) propagates; otherwise
- * the non-short-circuit value resolves.
+ * exhaustion with no decisive result, one recorded error (the
+ * first by completion order) propagates; otherwise the
+ * non-short-circuit value resolves. Which branch's error surfaces
+ * when several fail is scheduling-dependent, as it is in OpenFGA
+ * (whose union keeps the last-completed error instead).
+ *
+ * Exported for direct unit tests only; not part of the public
+ * package API (not re-exported from index.ts).
  */
-function resolveShortCircuit(
+export function resolveShortCircuit(
   handlers: Array<() => Promise<boolean>>,
   maxBreadth: number,
   shortCircuitOn: boolean,
 ): Promise<boolean> {
-  if (handlers.length === 0) {
-    return Promise.resolve(!shortCircuitOn);
-  }
-
   return new Promise((resolve, reject) => {
     let next = 0;
     let active = 0;
@@ -512,17 +533,21 @@ function resolveShortCircuit(
     let firstError: unknown;
     let hasError = false;
 
+    const settleExhausted = () => {
+      settled = true;
+      if (hasError) {
+        reject(firstError);
+      } else {
+        resolve(!shortCircuitOn);
+      }
+    };
+
     const onHandlerDone = () => {
       active--;
       if (next < handlers.length) {
         launch();
       } else if (active === 0) {
-        settled = true;
-        if (hasError) {
-          reject(firstError);
-        } else {
-          resolve(!shortCircuitOn);
-        }
+        settleExhausted();
       }
     };
 
@@ -532,7 +557,21 @@ function resolveShortCircuit(
         next++;
         if (!handler) continue;
         active++;
-        handler().then(
+        let branch: Promise<boolean>;
+        try {
+          branch = handler();
+        } catch (error) {
+          // A synchronously-throwing handler counts as a rejected
+          // branch; without this its slot would leak and the
+          // combinator could stall with nothing in flight.
+          active--;
+          if (!hasError) {
+            hasError = true;
+            firstError = error;
+          }
+          continue;
+        }
+        branch.then(
           (result) => {
             if (settled) return;
             if (result === shortCircuitOn) {
@@ -551,6 +590,12 @@ function resolveShortCircuit(
             onHandlerDone();
           },
         );
+      }
+      // Empty input, holes, and synchronous throws can exhaust the
+      // array with nothing in flight; settle here so the returned
+      // promise can never stall.
+      if (!settled && active === 0 && next >= handlers.length) {
+        settleExhausted();
       }
     };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,14 @@ export interface CheckRequest {
 export interface CheckOptions {
   /** Maximum recursion depth (default: 25) */
   maxDepth?: number;
+  /**
+   * Maximum number of branches of one resolution node evaluated
+   * concurrently (default: Infinity — unbounded). Mirrors
+   * OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. Bounding
+   * breadth only reorders work; it never changes answers.
+   * Must be at least 1.
+   */
+  maxBreadth?: number;
 }
 
 /** Parameters for adding a tuple */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,8 +68,9 @@ export interface CheckOptions {
    * Maximum number of branches of one resolution node evaluated
    * concurrently (default: Infinity — unbounded). Mirrors
    * OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. Bounding
-   * breadth only reorders work; it never changes answers.
-   * Must be at least 1.
+   * breadth never changes the boolean result or whether a check
+   * errors — only which branch's error surfaces when several
+   * fail. Must be an integer >= 1, or Infinity.
    */
   maxBreadth?: number;
 }

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { check } from "../src/check.ts";
-import { DepthExceededError, TsfgaError } from "../src/errors.ts";
-import type { RelationConfig, Tuple } from "../src/types.ts";
+import { check, resolveShortCircuit } from "../src/check.ts";
+import {
+  ConditionNotFoundError,
+  DepthExceededError,
+  TsfgaError,
+} from "../src/errors.ts";
+import type {
+  ConditionDefinition,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
 function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
@@ -91,6 +99,19 @@ class GatedConfigStore extends MockTupleStore {
     const result = await super.findRelationConfig(objectType, relation);
     this.configInflight--;
     return result;
+  }
+}
+
+/**
+ * Delays condition-definition lookups so a conditioned branch
+ * errors late while a cycling sibling errors immediately.
+ */
+class SlowConditionLookupStore extends MockTupleStore {
+  override async findConditionDefinition(
+    name: string,
+  ): Promise<ConditionDefinition | null> {
+    await delay(30);
+    return super.findConditionDefinition(name);
   }
 }
 
@@ -405,5 +426,138 @@ describe("error semantics under bounded breadth", () => {
     // Let the losing branch reject; an unhandled rejection would
     // fail the run.
     await delay(50);
+  });
+});
+
+describe("adversarial-review regressions", () => {
+  test("rejects fractional maxBreadth", () => {
+    // 1.5 would admit 2 branches in flight (`active < 1.5`),
+    // silently exceeding the stated bound.
+    const store = new MockTupleStore();
+    expect(
+      check(store, viewerRequest, { maxBreadth: 1.5 }),
+    ).rejects.toBeInstanceOf(TsfgaError);
+  });
+
+  test("empty intersection config errors instead of granting", () => {
+    // A zero-operand intersection used to resolve vacuously true
+    // for every subject. OpenFGA's typesystem rejects set
+    // operations with too few children as an invalid model.
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "access",
+        intersection: [],
+      }),
+    );
+    expect(
+      check(store, { ...viewerRequest, relation: "access" }),
+    ).rejects.toBeInstanceOf(TsfgaError);
+  });
+
+  test("surfaced error class is pinned to array order at breadth 1", async () => {
+    // Two failing branches with different error classes: slowerr
+    // (first in array, ConditionNotFoundError after a delayed
+    // condition lookup) and fasterr (cycle, DepthExceededError
+    // immediately). The boolean/reject status is breadth-invariant
+    // but the surfaced class is completion-ordered: breadth 1
+    // completes in array order, unbounded lets the fast error
+    // record first. Pinned as accepted, upstream-matching
+    // nondeterminism (OpenFGA's union keeps a completion-ordered
+    // error too).
+    function makeStore(): MockTupleStore {
+      const store = new SlowConditionLookupStore();
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          impliedBy: ["slowerr", "fasterr"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "slowerr",
+          directlyAssignableTypes: ["user"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "fasterr",
+          impliedBy: ["viewer"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "slowerr",
+          subjectType: "user",
+          subjectId: "anne",
+          conditionName: "missing_definition",
+        }),
+      );
+      return store;
+    }
+
+    expect(
+      check(makeStore(), viewerRequest, { maxBreadth: 1 }),
+    ).rejects.toBeInstanceOf(ConditionNotFoundError);
+    expect(check(makeStore(), viewerRequest, {})).rejects.toBeInstanceOf(
+      DepthExceededError,
+    );
+  });
+});
+
+describe("resolveShortCircuit hardening", () => {
+  // Direct combinator tests: neither trap is reachable through
+  // check() (it only builds dense arrays of async closures), so
+  // the latent liveness bugs found in review are pinned here
+  // against the exported combinator itself.
+
+  class SyncBoom extends Error {}
+
+  test("array holes cannot stall the combinator", async () => {
+    // Before hardening, a hole consumed on the refill path could
+    // exhaust the array with nothing in flight and never settle.
+    const handlers: Array<() => Promise<boolean>> = [];
+    handlers[0] = async () => false;
+    handlers[2] = async () => false;
+    expect(await resolveShortCircuit(handlers, 1, true)).toBe(false);
+
+    const onlyHoles: Array<() => Promise<boolean>> = [];
+    onlyHoles.length = 3;
+    expect(await resolveShortCircuit(onlyHoles, 2, true)).toBe(false);
+    expect(await resolveShortCircuit([], 1, false)).toBe(true);
+  });
+
+  test("synchronously-throwing handler counts as a rejected branch", async () => {
+    // Before hardening, a sync throw launched from the refill path
+    // leaked its slot (permanent active over-count -> stall) and
+    // escaped as an unhandled rejection.
+    const thrower = (): Promise<boolean> => {
+      throw new SyncBoom("sync boom");
+    };
+
+    const laterTrueWins = await resolveShortCircuit(
+      [async () => false, thrower, async () => true],
+      1,
+      true,
+    );
+    expect(laterTrueWins).toBe(true);
+
+    expect(
+      resolveShortCircuit([async () => false, thrower], 1, true),
+    ).rejects.toBeInstanceOf(SyncBoom);
+
+    // Intersection dual: a sync throw with no definitive false
+    // rejects; a definitive false still beats it.
+    expect(
+      resolveShortCircuit([async () => true, thrower], 1, false),
+    ).rejects.toBeInstanceOf(SyncBoom);
+    const falseBeatsThrow = await resolveShortCircuit(
+      [thrower, async () => false],
+      1,
+      false,
+    );
+    expect(falseBeatsThrow).toBe(false);
   });
 });

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import { DepthExceededError, TsfgaError } from "../src/errors.ts";
+import type { RelationConfig, Tuple } from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Records which relations are probed (direct reads and config
+ * reads), so tests can assert that queued branches beyond the
+ * breadth limit never start once the node has settled.
+ */
+class RecordingStore extends MockTupleStore {
+  probedRelations: string[] = [];
+  configRelations: string[] = [];
+
+  override findDirectTuple(
+    objectType: string,
+    objectId: string,
+    relation: string,
+    subjectType: string,
+    subjectId: string,
+  ): Promise<Tuple | null> {
+    this.probedRelations.push(relation);
+    return super.findDirectTuple(
+      objectType,
+      objectId,
+      relation,
+      subjectType,
+      subjectId,
+    );
+  }
+
+  override findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    this.configRelations.push(relation);
+    return super.findRelationConfig(objectType, relation);
+  }
+}
+
+/**
+ * Holds config reads open and records the maximum number in
+ * flight at once. Increments happen synchronously at call time,
+ * so the high-water mark is deterministic.
+ */
+class GatedConfigStore extends MockTupleStore {
+  configHighWater = 0;
+  private configInflight = 0;
+
+  override async findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    this.configInflight++;
+    this.configHighWater = Math.max(this.configHighWater, this.configInflight);
+    await delay(10);
+    const result = await super.findRelationConfig(objectType, relation);
+    this.configInflight--;
+    return result;
+  }
+}
+
+/**
+ * Seed a store so doc:1#viewer is implied by the given relations
+ * and a direct tuple grants (only) the relations in `granted` to
+ * user:anne. Returns the store for chaining.
+ */
+function seedUnion<S extends MockTupleStore>(
+  store: S,
+  implied: string[],
+  granted: string[],
+): S {
+  store.relationConfigs.push(
+    makeConfig({ objectType: "doc", relation: "viewer", impliedBy: implied }),
+  );
+  for (const relation of implied) {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation,
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+  }
+  for (const relation of granted) {
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation,
+        subjectType: "user",
+        subjectId: "anne",
+      }),
+    );
+  }
+  return store;
+}
+
+const viewerRequest = {
+  objectType: "doc",
+  objectId: "1",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "anne",
+};
+
+describe("maxBreadth validation", () => {
+  test("rejects zero", () => {
+    const store = new MockTupleStore();
+    expect(
+      check(store, viewerRequest, { maxBreadth: 0 }),
+    ).rejects.toBeInstanceOf(TsfgaError);
+  });
+
+  test("rejects negative values", () => {
+    const store = new MockTupleStore();
+    expect(
+      check(store, viewerRequest, { maxBreadth: -3 }),
+    ).rejects.toBeInstanceOf(TsfgaError);
+  });
+
+  test("rejects NaN", () => {
+    const store = new MockTupleStore();
+    expect(
+      check(store, viewerRequest, { maxBreadth: Number.NaN }),
+    ).rejects.toBeInstanceOf(TsfgaError);
+  });
+});
+
+describe("sequential equivalence across breadths", () => {
+  const breadths = [1, 2, 3, Number.POSITIVE_INFINITY];
+
+  for (const maxBreadth of breadths) {
+    test(`union hit on last branch at breadth ${maxBreadth}`, async () => {
+      const store = seedUnion(
+        new MockTupleStore(),
+        ["a", "b", "c", "d"],
+        ["d"],
+      );
+      const result = await check(store, viewerRequest, { maxBreadth });
+      expect(result).toBe(true);
+    });
+
+    test(`union miss at breadth ${maxBreadth}`, async () => {
+      const store = seedUnion(new MockTupleStore(), ["a", "b", "c", "d"], []);
+      const result = await check(store, viewerRequest, { maxBreadth });
+      expect(result).toBe(false);
+    });
+
+    test(`intersection at breadth ${maxBreadth}`, async () => {
+      const store = new MockTupleStore();
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "access",
+          directlyAssignableTypes: ["user"],
+          intersection: [
+            { type: "direct" },
+            { type: "computedUserset", relation: "member" },
+          ],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "access",
+          subjectType: "user",
+          subjectId: "anne",
+        }),
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "member",
+          subjectType: "user",
+          subjectId: "anne",
+        }),
+      );
+      const granted = await check(
+        store,
+        { ...viewerRequest, relation: "access" },
+        { maxBreadth },
+      );
+      expect(granted).toBe(true);
+
+      const denied = await check(
+        store,
+        { ...viewerRequest, relation: "access", subjectId: "bob" },
+        { maxBreadth },
+      );
+      expect(denied).toBe(false);
+    });
+  }
+});
+
+describe("bounded launch behavior", () => {
+  test("queued branches never start after a win at breadth 1", async () => {
+    const recording = seedUnion(
+      new RecordingStore(),
+      ["granted", "never"],
+      ["granted"],
+    );
+    const result = await check(recording, viewerRequest, { maxBreadth: 1 });
+    expect(result).toBe(true);
+    expect(recording.probedRelations.includes("never")).toBe(false);
+  });
+
+  test("the same branch does start at unbounded breadth", async () => {
+    const recording = seedUnion(
+      new RecordingStore(),
+      ["granted", "never"],
+      ["granted"],
+    );
+    const result = await check(recording, viewerRequest, {});
+    expect(result).toBe(true);
+    expect(recording.probedRelations.includes("never")).toBe(true);
+  });
+
+  test("all-false union visits every branch at breadth 1", async () => {
+    const recording = seedUnion(new RecordingStore(), ["r1", "r2", "r3"], []);
+    const result = await check(recording, viewerRequest, { maxBreadth: 1 });
+    expect(result).toBe(false);
+    expect(recording.probedRelations.includes("r1")).toBe(true);
+    expect(recording.probedRelations.includes("r2")).toBe(true);
+    expect(recording.probedRelations.includes("r3")).toBe(true);
+  });
+
+  test("false intersection operand skips queued operands at breadth 1", async () => {
+    const recording = new RecordingStore();
+    recording.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "access",
+        directlyAssignableTypes: ["user"],
+        intersection: [
+          { type: "direct" },
+          { type: "computedUserset", relation: "member" },
+        ],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    const result = await check(
+      recording,
+      { ...viewerRequest, relation: "access" },
+      { maxBreadth: 1 },
+    );
+    expect(result).toBe(false);
+    expect(recording.configRelations.includes("member")).toBe(false);
+  });
+
+  test("breadth bounds concurrent branch resolution", async () => {
+    const relations = ["r1", "r2", "r3", "r4"];
+    const bounded = seedUnion(new GatedConfigStore(), relations, []);
+    await check(bounded, viewerRequest, { maxBreadth: 1 });
+    expect(bounded.configHighWater).toBe(1);
+
+    const unbounded = seedUnion(new GatedConfigStore(), relations, []);
+    await check(unbounded, viewerRequest, {});
+    expect(unbounded.configHighWater).toBe(4);
+  });
+});
+
+describe("error semantics under bounded breadth", () => {
+  /** viewer implied by [looper, ...rest]; looper cycles back. */
+  function erringStore(rest: string[], granted: string[]): MockTupleStore {
+    const store = seedUnion(new MockTupleStore(), rest, granted);
+    const viewer = store.relationConfigs.find((c) => c.relation === "viewer");
+    if (viewer) {
+      viewer.impliedBy = ["looper", ...rest];
+    }
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "looper",
+        impliedBy: ["viewer"],
+      }),
+    );
+    return store;
+  }
+
+  test("error plus all-false at breadth 1 propagates the error", () => {
+    const store = erringStore(["r2"], []);
+    expect(
+      check(store, viewerRequest, { maxBreadth: 1 }),
+    ).rejects.toBeInstanceOf(DepthExceededError);
+  });
+
+  test("a later true beats an earlier error at breadth 1", async () => {
+    const store = erringStore(["granted"], ["granted"]);
+    const result = await check(store, viewerRequest, { maxBreadth: 1 });
+    expect(result).toBe(true);
+  });
+
+  test("false intersection operand beats an errored sibling at breadth 1", async () => {
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "access",
+        intersection: [
+          { type: "computedUserset", relation: "looper" },
+          { type: "computedUserset", relation: "member" },
+        ],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "looper",
+        impliedBy: ["access"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "member",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    const result = await check(
+      store,
+      { ...viewerRequest, relation: "access" },
+      { maxBreadth: 1 },
+    );
+    expect(result).toBe(false);
+  });
+
+  test("losing branch that errors after a win still resolves true", async () => {
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        impliedBy: ["granted", "slowlooper"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "granted",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "granted",
+        subjectType: "user",
+        subjectId: "anne",
+      }),
+    );
+    const original = store.findRelationConfig.bind(store);
+    store.findRelationConfig = async (objectType, relation) => {
+      if (relation === "slowlooper") {
+        await delay(20);
+        return makeConfig({
+          objectType: "doc",
+          relation: "slowlooper",
+          impliedBy: ["viewer"],
+        });
+      }
+      return original(objectType, relation);
+    };
+
+    const result = await check(store, viewerRequest, { maxBreadth: 2 });
+    expect(result).toBe(true);
+    // Let the losing branch reject; an unhandled rejection would
+    // fail the run.
+    await delay(50);
+  });
+});


### PR DESCRIPTION
Adds `CheckOptions.maxBreadth` — the number of branches of one
resolution node evaluated concurrently — mirroring OpenFGA's
`OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`, which upstream passes as the
concurrency limit of its union/intersection reducers. The default
stays `Infinity`, so this PR is behavior-preserving; flipping the
default to 10 (OpenFGA's default) is a follow-up.

## Commit 1 — Bound node fanout with a maxBreadth option

- `resolveUnion`/`resolveIntersection` become thin wrappers over one
  shared bounded pull-model combinator (they are exact duals: the
  short-circuit value and exhaustion value flip).
- Handlers launch in array order while fewer than `maxBreadth` are in
  flight; each settlement pulls the next queued handler; once the
  result is decided nothing new starts, and in-flight losers'
  rejections are consumed by callbacks attached at launch.
- Exclusion keeps its fixed breadth of 2, as upstream does.
- At `Infinity` the launch loop starts every handler synchronously
  before any can settle — identical to the previous launch-all
  combinators (verified by the full existing suite and an 800-case
  seeded differential fuzz against the parent commit: 0 mismatches).

## Commit 2 — Harden breadth combinator from review findings

Two independent adversarial review passes (combinator accounting and
liveness; OpenFGA semantic parity) surfaced no reachable bug, but
several items worth fixing, each reproduced by test first:

- **Liveness made structural**: a falsy handler entry consumed on the
  refill path, or a handler throwing synchronously after claiming its
  slot, could stall the combinator with nothing in flight (and the
  sync throw escaped as an unhandled rejection). Neither is
  constructible through `check()` today — dense arrays of async
  closures only — but the invariants were convention-enforced. Sync
  throws now count as rejected branches and the launch loop settles
  on exhaustion. The combinator is exported (not via the package
  barrel) so regression tests exercise it with inputs `check()`
  cannot build.
- **Integer-only `maxBreadth`**: a fractional bound admits one more
  branch than stated (`active < 1.5` allows 2 in flight). Validation
  now requires an integer >= 1 or `Infinity`; anything else throws
  `TsfgaError`.
- **Empty intersections fail closed** (pre-existing fail-open): a
  zero-operand intersection resolved vacuously true for every
  subject. OpenFGA's typesystem rejects set operations with too few
  children as an invalid model, so it now throws `TsfgaError`.
  Single-operand intersections stay valid — tsfga's decomposed
  configs use them legitimately, unlike the DSL.
- **Docs corrected**: breadth never changes the boolean result or
  resolve/reject status, but when several branches fail, which
  branch's error surfaces follows completion order — the same
  nondeterminism OpenFGA has (its union keeps the last-completed
  error). Pinned by a deterministic two-error-class test.

## Semantics guarantees (pinned by tests)

- Sequential equivalence at breadths 1/2/3/∞ for union and
  intersection; queued branches never start after settlement;
  all-false visits every branch; deterministic concurrency high-water
  (1 at breadth 1, N unbounded).
- True-beats-error and false-beats-error survive bounding (an
  erroring branch's settlement pulls the queued decisive branch);
  depth/cycle detection is queue-independent (captured at handler
  construction).
- The speculative node-read batch cannot leak an unhandled rejection
  when an intersection's `direct` operand is never launched.

## Testing

- Core: 135/135 on Bun, Node (22/24/26 shims), and Deno — includes
  29 tests in the new `check-breadth.test.ts`.
- Kysely adapter: 49/49. Conformance vs real OpenFGA: **341/341**.
- Bench (pool 10): no regression at `Infinity` (store-call counts
  identical: 3005/40/306). Preview at breadth 10: wide-union hit
  270→108 ms median with 3005→1166 store calls; TTU hit 41→17 ms —
  hits get faster *and* cheaper because queued branches never start
  after a win. Misses are flat-to-better.

Refs (pinned to openfga/openfga @ 81c6202, v1.18.3):
- https://github.com/openfga/openfga/blob/81c6202153a853d90589565884a56942c3fd07be/internal/graph/check.go
- https://github.com/openfga/openfga/blob/81c6202153a853d90589565884a56942c3fd07be/pkg/typesystem/typesystem.go
