### PR TITLE
Default maxBreadth to 10 to match OpenFGA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,9 @@ export interface CheckOptions {
   maxDepth?: number;
   /**
    * Maximum branches of one resolution node evaluated
-   * concurrently (default: Infinity). Mirrors OpenFGA's
-   * OPENFGA_RESOLVE_NODE_BREADTH_LIMIT. Integer >= 1 or
-   * Infinity.
+   * concurrently (default: 10, OpenFGA's default
+   * OPENFGA_RESOLVE_NODE_BREADTH_LIMIT). Integer >= 1 or
+   * Infinity (unbounded).
    */
   maxBreadth?: number;
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -98,9 +98,10 @@ resolution at the same model depth.
 ## Breadth limits
 
 Branches of one resolution node are evaluated concurrently,
-bounded by `maxBreadth` (default `Infinity` — unbounded, via
-the same options object as `maxDepth`). The option mirrors
-OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. Bounding
+bounded by `maxBreadth` (default 10, via the same options
+object as `maxDepth`). The default matches OpenFGA's default
+`OPENFGA_RESOLVE_NODE_BREADTH_LIMIT` (10); pass
+`maxBreadth: Infinity` to restore unbounded fanout. Bounding
 breadth never changes the boolean result or whether a check
 errors — it caps how many concurrent store reads a single wide
 node can issue (useful to avoid saturating a connection pool).

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -45,8 +45,9 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  *   InvalidSubjectTypeError, UsersetNotAllowedError).
  *
  * Concurrency: branches of one resolution node run concurrently,
- * bounded by `options.maxBreadth` (default Infinity — unbounded),
- * mirroring OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`.
+ * bounded by `options.maxBreadth` (default 10, matching OpenFGA's
+ * default `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`; pass Infinity for
+ * unbounded fanout).
  * Breadth never changes the boolean result or whether a check
  * resolves versus rejects; when several branches fail, which
  * branch's error surfaces depends on completion order — the same
@@ -58,7 +59,7 @@ export async function check(
   options: CheckOptions = {},
 ): Promise<boolean> {
   const maxDepth = options.maxDepth ?? 25;
-  const maxBreadth = options.maxBreadth ?? Number.POSITIVE_INFINITY;
+  const maxBreadth = options.maxBreadth ?? 10;
   // The negated comparison also rejects NaN, which `< 1` misses.
   // Fractional values would admit one more branch than stated
   // (`active < 1.5` allows 2 in flight), so only integers — and

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -66,11 +66,12 @@ export interface CheckOptions {
   maxDepth?: number;
   /**
    * Maximum number of branches of one resolution node evaluated
-   * concurrently (default: Infinity — unbounded). Mirrors
-   * OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. Bounding
-   * breadth never changes the boolean result or whether a check
-   * errors — only which branch's error surfaces when several
-   * fail. Must be an integer >= 1, or Infinity.
+   * concurrently (default: 10, matching OpenFGA's default
+   * `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`; pass Infinity to
+   * restore unbounded fanout). Bounding breadth never changes
+   * the boolean result or whether a check errors — only which
+   * branch's error surfaces when several fail. Must be an
+   * integer >= 1, or Infinity.
    */
   maxBreadth?: number;
 }

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -160,23 +160,23 @@ const viewerRequest = {
 };
 
 describe("maxBreadth validation", () => {
-  test("rejects zero", () => {
+  test("rejects zero", async () => {
     const store = new MockTupleStore();
-    expect(
+    await expect(
       check(store, viewerRequest, { maxBreadth: 0 }),
     ).rejects.toBeInstanceOf(TsfgaError);
   });
 
-  test("rejects negative values", () => {
+  test("rejects negative values", async () => {
     const store = new MockTupleStore();
-    expect(
+    await expect(
       check(store, viewerRequest, { maxBreadth: -3 }),
     ).rejects.toBeInstanceOf(TsfgaError);
   });
 
-  test("rejects NaN", () => {
+  test("rejects NaN", async () => {
     const store = new MockTupleStore();
-    expect(
+    await expect(
       check(store, viewerRequest, { maxBreadth: Number.NaN }),
     ).rejects.toBeInstanceOf(TsfgaError);
   });
@@ -361,9 +361,9 @@ describe("error semantics under bounded breadth", () => {
     return store;
   }
 
-  test("error plus all-false at breadth 1 propagates the error", () => {
+  test("error plus all-false at breadth 1 propagates the error", async () => {
     const store = erringStore(["r2"], []);
-    expect(
+    await expect(
       check(store, viewerRequest, { maxBreadth: 1 }),
     ).rejects.toBeInstanceOf(DepthExceededError);
   });
@@ -449,16 +449,16 @@ describe("error semantics under bounded breadth", () => {
 });
 
 describe("adversarial-review regressions", () => {
-  test("rejects fractional maxBreadth", () => {
+  test("rejects fractional maxBreadth", async () => {
     // 1.5 would admit 2 branches in flight (`active < 1.5`),
     // silently exceeding the stated bound.
     const store = new MockTupleStore();
-    expect(
+    await expect(
       check(store, viewerRequest, { maxBreadth: 1.5 }),
     ).rejects.toBeInstanceOf(TsfgaError);
   });
 
-  test("empty intersection config errors instead of granting", () => {
+  test("empty intersection config errors instead of granting", async () => {
     // A zero-operand intersection used to resolve vacuously true
     // for every subject. OpenFGA's typesystem rejects set
     // operations with too few children as an invalid model.
@@ -470,7 +470,7 @@ describe("adversarial-review regressions", () => {
         intersection: [],
       }),
     );
-    expect(
+    await expect(
       check(store, { ...viewerRequest, relation: "access" }),
     ).rejects.toBeInstanceOf(TsfgaError);
   });
@@ -517,10 +517,10 @@ describe("adversarial-review regressions", () => {
       return store;
     }
 
-    expect(
+    await expect(
       check(makeStore(), viewerRequest, { maxBreadth: 1 }),
     ).rejects.toBeInstanceOf(ConditionNotFoundError);
-    expect(
+    await expect(
       check(makeStore(), viewerRequest, {
         maxBreadth: Number.POSITIVE_INFINITY,
       }),
@@ -565,13 +565,13 @@ describe("resolveShortCircuit hardening", () => {
     );
     expect(laterTrueWins).toBe(true);
 
-    expect(
+    await expect(
       resolveShortCircuit([async () => false, thrower], 1, true),
     ).rejects.toBeInstanceOf(SyncBoom);
 
     // Intersection dual: a sync throw with no definitive false
     // rejects; a definitive false still beats it.
-    expect(
+    await expect(
       resolveShortCircuit([async () => true, thrower], 1, false),
     ).rejects.toBeInstanceOf(SyncBoom);
     const falseBeatsThrow = await resolveShortCircuit(

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -271,7 +271,9 @@ describe("bounded launch behavior", () => {
       ["granted", "never"],
       ["granted"],
     );
-    const result = await check(recording, viewerRequest, {});
+    const result = await check(recording, viewerRequest, {
+      maxBreadth: Number.POSITIVE_INFINITY,
+    });
     expect(result).toBe(true);
     expect(recording.probedRelations.includes("never")).toBe(true);
   });
@@ -319,8 +321,25 @@ describe("bounded launch behavior", () => {
     expect(bounded.configHighWater).toBe(1);
 
     const unbounded = seedUnion(new GatedConfigStore(), relations, []);
-    await check(unbounded, viewerRequest, {});
+    await check(unbounded, viewerRequest, {
+      maxBreadth: Number.POSITIVE_INFINITY,
+    });
     expect(unbounded.configHighWater).toBe(4);
+  });
+
+  test("default maxBreadth is 10, matching OpenFGA's default", async () => {
+    // 12 branches: the default admits exactly 10 in flight;
+    // explicit Infinity restores unbounded fanout.
+    const relations = Array.from({ length: 12 }, (_, i) => `r${i}`);
+    const defaulted = seedUnion(new GatedConfigStore(), relations, []);
+    await check(defaulted, viewerRequest, {});
+    expect(defaulted.configHighWater).toBe(10);
+
+    const unbounded = seedUnion(new GatedConfigStore(), relations, []);
+    await check(unbounded, viewerRequest, {
+      maxBreadth: Number.POSITIVE_INFINITY,
+    });
+    expect(unbounded.configHighWater).toBe(12);
   });
 });
 
@@ -501,9 +520,11 @@ describe("adversarial-review regressions", () => {
     expect(
       check(makeStore(), viewerRequest, { maxBreadth: 1 }),
     ).rejects.toBeInstanceOf(ConditionNotFoundError);
-    expect(check(makeStore(), viewerRequest, {})).rejects.toBeInstanceOf(
-      DepthExceededError,
-    );
+    expect(
+      check(makeStore(), viewerRequest, {
+        maxBreadth: Number.POSITIVE_INFINITY,
+      }),
+    ).rejects.toBeInstanceOf(DepthExceededError);
   });
 });
 

--- a/tests/conformance/wide-union.test.ts
+++ b/tests/conformance/wide-union.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeAll, describe, test } from "bun:test";
+import { createTsfga, type TsfgaClient } from "@tsfga/core";
+import type { DB } from "@tsfga/kysely";
+import { KyselyTupleStore } from "@tsfga/kysely";
+import type { Kysely } from "kysely";
+import { expectConformance } from "./helpers/conformance.ts";
+import {
+  beginTransaction,
+  destroyDb,
+  getDb,
+  rollbackTransaction,
+} from "./helpers/db.ts";
+import {
+  fgaCreateStore,
+  fgaWriteModel,
+  fgaWriteTuples,
+} from "./helpers/openfga.ts";
+
+// A single node (document:1#viewer) fanning out to 12 userset
+// branches — wider than the default maxBreadth of 10 — so the
+// conformance suite exercises the bounded pull-model combinator's
+// queued-branch path against real OpenFGA, not just in-window
+// launches. Grants are placed both inside the launch window
+// (team1) and past it (team12), and the miss case must traverse
+// all 12 branches.
+//
+// Ref: https://github.com/openfga/openfga/blob/81c6202153a853d90589565884a56942c3fd07be/pkg/server/config/config.go#L26
+// (DefaultResolveNodeBreadthLimit = 10 — same default as tsfga)
+
+const TEAM_COUNT = 12;
+
+const uuidMap = new Map<string, string>([
+  ["anne", "00000000-0000-4000-c500-000000000001"],
+  ["bob", "00000000-0000-4000-c500-000000000002"],
+  ["carl", "00000000-0000-4000-c500-000000000003"],
+  ["1", "00000000-0000-4000-c500-000000000004"],
+]);
+for (let i = 1; i <= TEAM_COUNT; i++) {
+  const suffix = (16 + i).toString(16).padStart(2, "0");
+  uuidMap.set(`team${i}`, `00000000-0000-4000-c500-0000000000${suffix}`);
+}
+
+function uuid(name: string): string {
+  const id = uuidMap.get(name);
+  if (!id) throw new Error(`No UUID for ${name}`);
+  return id;
+}
+
+describe("Wide Union Conformance", () => {
+  let db: Kysely<DB>;
+  let storeId: string;
+  let authorizationModelId: string;
+  let tsfgaClient: TsfgaClient;
+
+  beforeAll(async () => {
+    db = getDb();
+    await beginTransaction(db);
+
+    const store = new KyselyTupleStore(db);
+    tsfgaClient = createTsfga(store);
+
+    // === Relation configs ===
+    await tsfgaClient.writeRelationConfig({
+      objectType: "team",
+      relation: "member",
+      directlyAssignableTypes: ["user"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "viewer",
+      directlyAssignableTypes: ["team"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: true,
+    });
+
+    // === Tuples: 12 userset branches on one node ===
+    for (let i = 1; i <= TEAM_COUNT; i++) {
+      await tsfgaClient.addTuple({
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "team",
+        subjectId: uuid(`team${i}`),
+        subjectRelation: "member",
+      });
+    }
+    // anne only in the last team (queued past the default launch
+    // window); bob only in the first (in-window).
+    await tsfgaClient.addTuple({
+      objectType: "team",
+      objectId: uuid(`team${TEAM_COUNT}`),
+      relation: "member",
+      subjectType: "user",
+      subjectId: uuid("anne"),
+    });
+    await tsfgaClient.addTuple({
+      objectType: "team",
+      objectId: uuid("team1"),
+      relation: "member",
+      subjectType: "user",
+      subjectId: uuid("bob"),
+    });
+
+    // Setup OpenFGA
+    storeId = await fgaCreateStore("wide-union-conformance");
+    authorizationModelId = await fgaWriteModel(
+      storeId,
+      "./wide-union/model.dsl",
+    );
+    await fgaWriteTuples(
+      storeId,
+      "./wide-union/tuples.yaml",
+      authorizationModelId,
+      uuidMap,
+    );
+  });
+
+  afterAll(async () => {
+    await rollbackTransaction(db);
+    await destroyDb();
+  });
+
+  test("1: grant found in a branch queued past the window", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("anne"),
+      },
+      true,
+    );
+  });
+
+  test("2: grant found in an in-window branch", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("bob"),
+      },
+      true,
+    );
+  });
+
+  test("3: miss traverses all branches", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: uuid("carl"),
+      },
+      false,
+    );
+  });
+});

--- a/tests/conformance/wide-union/model.dsl
+++ b/tests/conformance/wide-union/model.dsl
@@ -1,0 +1,12 @@
+model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define member: [user]
+
+type document
+  relations
+    define viewer: [team#member]

--- a/tests/conformance/wide-union/tuples.yaml
+++ b/tests/conformance/wide-union/tuples.yaml
@@ -1,0 +1,49 @@
+# document:1 viewer fans out to 12 team#member userset
+# branches — wider than the default maxBreadth of 10, so
+# resolving it exercises the queued-branch pull path.
+- user: team:team1#member
+  relation: viewer
+  object: document:1
+- user: team:team2#member
+  relation: viewer
+  object: document:1
+- user: team:team3#member
+  relation: viewer
+  object: document:1
+- user: team:team4#member
+  relation: viewer
+  object: document:1
+- user: team:team5#member
+  relation: viewer
+  object: document:1
+- user: team:team6#member
+  relation: viewer
+  object: document:1
+- user: team:team7#member
+  relation: viewer
+  object: document:1
+- user: team:team8#member
+  relation: viewer
+  object: document:1
+- user: team:team9#member
+  relation: viewer
+  object: document:1
+- user: team:team10#member
+  relation: viewer
+  object: document:1
+- user: team:team11#member
+  relation: viewer
+  object: document:1
+- user: team:team12#member
+  relation: viewer
+  object: document:1
+
+# anne is only in team12 (the last, queued-past-the-window
+# branch at the default breadth); bob only in team1 (an
+# in-window branch); carl is in no team.
+- user: user:anne
+  relation: member
+  object: team:team12
+- user: user:bob
+  relation: member
+  object: team:team1


### PR DESCRIPTION
Flips the `maxBreadth` default from `Infinity` to 10 — OpenFGA's
`DefaultResolveNodeBreadthLimit` — so both systems bound node fanout
identically out of the box. The option shipped unbounded in #63
precisely so this flip would be a one-line, independently reviewable
change. `maxBreadth: Infinity` restores the old behavior.

## Commit 1 — Default maxBreadth to 10 to match OpenFGA

- One-line default change (`options.maxBreadth ?? 10`); docs updated
  in check.ts, types.ts, the core README, and CLAUDE.md.
- Tests that meant "unbounded" now pass `Infinity` explicitly, and a
  new pin test asserts the default exactly: a 12-branch node runs
  precisely 10 branches concurrently under `{}` and 12 under
  `Infinity` (deterministic — increments are synchronous at launch).
- Bench: bounding never changes outcomes, but resource behavior
  improves on the common paths — a granted wide-union check stops
  launching queued branches once a branch wins (hit: ~270 ms/3005
  store calls → ~108 ms/1166; TTU hit: ~41 ms/306 → ~17 ms/192), and
  a single node can no longer flood the pool with an unbounded read
  burst. Known trade-off, measured and accepted: all-miss wide
  unions under 4-way concurrent load are ~20% slower than unbounded
  (the pull model leaves small pool-idle gaps between settlements);
  single-check misses remain flat-to-better.

## Commit 2 — Await rejects assertions; add wide conformance

Three adversarial review passes (behavior differential, upstream
scope parity, test robustness) produced two fixes, both verified
red-green:

- **Deno-vacuous assertions**: unawaited `expect(...).rejects` with a
  *delayed* rejection was never evaluated under the Deno shim — the
  suite finished first and the dropped assertion promise never
  surfaced. Mutation-proven: flipping the combinator's error
  recording to last-wins (the exact regression the error-identity
  test pins) passed green on Deno while failing Bun and Node. All
  rejects assertions are now awaited (also fixes Node's per-test
  failure attribution).
- **Wide conformance fixture**: no existing fixture exceeded 3
  branches at one node, so conformance could not distinguish
  breadth 10 from Infinity. The new wide-union suite fans one
  document out to 12 `team#member` userset branches — grants
  in-window, queued past the window, and a full-traversal miss —
  validated against real OpenFGA.

## Review results with no code change needed

- 600 randomized differential cases + 56 boundary runs (widths
  9/10/11, grants/errors at in-window and queued indices): zero
  boolean or resolve/reject differences between `{}`, 10, and
  `Infinity`; only the documented completion-order error-identity
  nondeterminism.
- `listObjects` checks candidates sequentially, so the flip cannot
  compound its fanout.
- Upstream applies no validation to its breadth limit and panics at
  runtime on 0 (`concurrency.NewPool`); tsfga's typed `TsfgaError`
  rejection is strictly safer while covering upstream's whole
  expressible range.
- Every timing-based assertion in the breadth/concurrency suites is
  microtask-vs-timer queue-ordered, not wall-clock dependent: 50
  stress runs green, including under full CPU saturation, across
  Bun, Node, and Deno.

## Testing

- Core: 136/136 on Bun and Node (22/24/26), 158 steps on Deno.
- Kysely adapter: 49/49. Conformance vs real OpenFGA: **344/344**
  (three new wide-union tests).
- Fork CI: https://github.com/lemuelroberto/tsfga/actions/runs/31073370045
  (all jobs green).

Note for the changelog at bump time: pre-1.0 default change —
callers who relied on unbounded fanout should pass
`maxBreadth: Infinity` explicitly.

Refs (pinned to openfga/openfga @ 81c6202, v1.18.3):
- https://github.com/openfga/openfga/blob/81c6202153a853d90589565884a56942c3fd07be/pkg/server/config/config.go#L26
