### PR TITLE
Charge depth only on dispatch, as OpenFGA does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,11 +318,12 @@ export async function check(
   options: CheckOptions = {},
   depth: number = 0,
 ): Promise<boolean> {
-  const maxDepth = options.maxDepth ?? 10;
+  const maxDepth = options.maxDepth ?? 25;
 
-  // Prevent infinite recursion
-  if (depth > maxDepth) {
-    return false;
+  // Prevent infinite recursion. Only dispatches to another object
+  // (steps 2 and 5) spend the budget, so the guard trips on `>=`.
+  if (depth >= maxDepth) {
+    throw new DepthExceededError(...);
   }
 
   // Step 1: Direct tuple check
@@ -376,10 +377,11 @@ export async function check(
   // → recursively check if user has "channels_admin" on the same object
   if (config?.impliedBy) {
     for (const impliedRelation of config.impliedBy) {
+      // Same object: a rewrite, not a dispatch — no depth cost
       const hasRelation = await check(store, {
         ...request,
         relation: impliedRelation,
-      }, options, depth + 1);
+      }, options, depth);
       if (hasRelation) {
         return true;
       }
@@ -390,10 +392,11 @@ export async function check(
   // e.g., for branch.can_merge, computed_userset = "can_push" means
   // users who can push can also merge (on the same object)
   if (config?.computedUserset) {
+    // Same object: a rewrite, not a dispatch — no depth cost
     const hasRelation = await check(store, {
       ...request,
       relation: config.computedUserset,
-    }, options, depth + 1);
+    }, options, depth);
     if (hasRelation) {
       return true;
     }
@@ -437,6 +440,13 @@ export async function check(
 - The `depth` parameter is internal; it is not exposed in the public API
 - `maxDepth` defaults to 25 (matching OpenFGA's
   `OPENFGA_RESOLVE_NODE_LIMIT`) but is configurable via `CheckOptions`
+- **Only dispatches spend depth.** Userset expansion (step 2) and
+  tuple-to-userset expansion (step 5) move to another object and cost
+  one depth each. Rewrites of the same object — `impliedBy` (step 3),
+  `computedUserset` (step 4), `excludedBy` and intersection operands —
+  cost none, matching OpenFGA, which increments resolution depth only
+  in `dispatch`. Unbounded rewrite recursion is prevented by the cycle
+  path, not by the depth budget
 
 ## CEL Conditions (`packages/core/src/conditions.ts`)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,26 @@ Notable changes to `@tsfga/core`. The format is based on
 follow [Semantic Versioning](https://semver.org/) (pre-1.0: minor
 releases may contain breaking changes).
 
+## Unreleased
+
+### Changed
+
+- **Only dispatches to another object spend the depth budget.**
+  Userset expansion and tuple-to-userset expansion cost one depth
+  each, as before; rewrites of the same object — `impliedBy`,
+  `computedUserset`, `excludedBy` and intersection operands — now
+  cost none. Previously every one of them charged a depth, so
+  tsfga exhausted `maxDepth` earlier than OpenFGA and threw
+  `DepthExceededError` on models OpenFGA resolves — reachable at
+  the default limit of 25. The guard also moved from
+  `depth > maxDepth` to `depth >= maxDepth`, matching OpenFGA's
+  `Depth == maxResolutionDepth`: a budget of `maxDepth` admits a
+  root node plus `maxDepth - 1` dispatches. Behavior-visible, not
+  an API change: checks that used to throw may now resolve, and a
+  check one dispatch past the limit throws where it previously
+  resolved. Long rewrite ladders are still bounded — by cycle
+  detection, since one object has a finite set of relations.
+
 ## 0.3.1 — 2026-08
 
 Maintenance release. No changes to the published code — the

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,6 +72,17 @@ argument of `createTsfga`). The default matches OpenFGA's
 `OPENFGA_RESOLVE_NODE_LIMIT` (25), so both systems exhaust
 resolution at the same model depth.
 
+**Only hops to another object spend the budget.** Userset
+expansion and tuple-to-userset expansion each cost one depth;
+rewrites of the same object — `impliedBy`, `computedUserset`,
+`excludedBy`, and intersection operands — cost none. This
+matches OpenFGA, which increments resolution depth solely when
+it dispatches to a child object. A rewrite ladder can therefore
+be arbitrarily long without exhausting the budget; it is
+bounded instead by cycle detection, since one object has a
+finite set of relations. A budget of `maxDepth` admits a root
+node plus `maxDepth - 1` dispatches.
+
 - When the budget is exhausted, or when the resolution path
   revisits a node it already contains (a cyclic model),
   `check()` throws `DepthExceededError` — mirroring OpenFGA's

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -30,6 +30,17 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  *   detected in the resolution path. Exhaustion is never converted
  *   to `false`: inside an exclusion or intersection branch that
  *   would fail open.
+ *
+ * Depth accounting: only steps that move to a *different object*
+ * — userset expansion and tuple-to-userset expansion — cost
+ * depth. Rewrites of the same object (implied_by, computed
+ * userset, exclusion, intersection operands) cost none. This
+ * mirrors OpenFGA, which increments resolution depth solely in
+ * `dispatch` (`internal/graph/check.go`, called only for userset
+ * and TTU children) and notes explicitly at `checkComputedUserset`
+ * that "we don't want to increase resolution depth". Rewrite
+ * recursion is bounded by the cycle path instead: the relation
+ * set of one object is finite, so it always terminates.
  * - Within union-style resolution (steps 1-5), a branch that
  *   resolves `true` wins even if a sibling branch threw
  *   DepthExceededError. If no branch resolves `true` and at least
@@ -117,7 +128,10 @@ async function checkNode(
   depth: number,
   path: ReadonlySet<string>,
 ): Promise<boolean> {
-  if (depth > maxDepth) {
+  // `depth` counts dispatches already made, so the budget is spent
+  // once it reaches maxDepth — OpenFGA errors on
+  // `Depth == maxResolutionDepth`, before resolving the node.
+  if (depth >= maxDepth) {
     throw new DepthExceededError(`max depth of ${maxDepth} exceeded`);
   }
 
@@ -177,12 +191,14 @@ async function checkNode(
     const excludedBy = config.excludedBy;
     const [baseResult, exclusionResult] = await Promise.allSettled([
       resolveBase(),
+      // Same object, a rewrite of it — no depth cost (upstream
+      // builds the subtract branch on the unchanged request).
       checkNode(
         store,
         { ...request, relation: excludedBy },
         maxDepth,
         maxBreadth,
-        depth + 1,
+        depth,
         visited,
       ),
     ]);
@@ -278,7 +294,8 @@ async function checkBase(
     );
   }
 
-  // Step 2: Userset expansion handlers
+  // Step 2: Userset expansion handlers. This moves to another
+  // object, so it is a dispatch and costs one depth.
   for (const userset of usersetTuples) {
     if (!userset.subjectRelation) continue;
     const relation = userset.subjectRelation;
@@ -304,7 +321,9 @@ async function checkBase(
     });
   }
 
-  // Step 3: Relation inheritance (implied_by) handlers
+  // Step 3: Relation inheritance (implied_by) handlers.
+  // Same object, so no depth cost — see the depth-accounting note
+  // on `check`.
   if (config?.impliedBy) {
     for (const impliedRelation of config.impliedBy) {
       handlers.push(() =>
@@ -313,14 +332,14 @@ async function checkBase(
           { ...request, relation: impliedRelation },
           maxDepth,
           maxBreadth,
-          depth + 1,
+          depth,
           path,
         ),
       );
     }
   }
 
-  // Step 4: Computed userset handler
+  // Step 4: Computed userset handler. Same object, no depth cost.
   if (config?.computedUserset) {
     const computedUserset = config.computedUserset;
     handlers.push(() =>
@@ -329,13 +348,14 @@ async function checkBase(
         { ...request, relation: computedUserset },
         maxDepth,
         maxBreadth,
-        depth + 1,
+        depth,
         path,
       ),
     );
   }
 
-  // Step 5: Tuple-to-userset composite handler
+  // Step 5: Tuple-to-userset composite handler. Like step 2 this
+  // moves to another object, so each child costs one depth.
   if (config?.tupleToUserset) {
     const ttuEntries = config.tupleToUserset;
     handlers.push(async () => {
@@ -424,13 +444,14 @@ async function checkIntersection(
         ),
       );
     } else if (operand.type === "computedUserset") {
+      // Same object, no depth cost — as with the other rewrites.
       handlers.push(() =>
         checkNode(
           store,
           { ...request, relation: operand.relation },
           maxDepth,
           maxBreadth,
-          depth + 1,
+          depth,
           path,
         ),
       );

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -860,10 +860,11 @@ describe("check algorithm", () => {
   describe("Max depth protection", () => {
     /**
      * Build a computedUserset chain lvl0 -> lvl1 -> ... -> lvlN
-     * with a direct tuple at lvlN. Resolving lvl0 requires N
-     * recursion steps.
+     * with a direct tuple at lvlN, all on doc:1. Every hop is a
+     * rewrite of the same object, so the whole chain costs zero
+     * depth.
      */
-    function buildChain(length: number) {
+    function buildRewriteChain(length: number) {
       for (let i = 0; i < length; i++) {
         store.relationConfigs.push(
           makeConfig({
@@ -884,8 +885,58 @@ describe("check algorithm", () => {
       );
     }
 
-    test("resolves when chain depth is exactly at the limit", async () => {
-      buildChain(3);
+    /**
+     * Build a userset chain group:0#member <- group:1#member <-
+     * ... <- group:N#member with a direct tuple at group:N.
+     * Resolving group:0 takes N dispatches, so it needs a budget
+     * of N + 1.
+     */
+    function buildUsersetChain(length: number) {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "group",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: true,
+        }),
+      );
+      for (let i = 0; i < length; i++) {
+        store.tuples.push(
+          makeTuple({
+            objectType: "group",
+            objectId: String(i),
+            relation: "member",
+            subjectType: "group",
+            subjectId: String(i + 1),
+            subjectRelation: "member",
+          }),
+        );
+      }
+      store.tuples.push(
+        makeTuple({
+          objectType: "group",
+          objectId: String(length),
+          relation: "member",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+    }
+
+    const groupRequest = {
+      objectType: "group",
+      objectId: "0",
+      relation: "member",
+      subjectType: "user",
+      subjectId: "alice",
+    };
+
+    test("rewrites of the same object cost no depth", async () => {
+      // Three computed-userset hops resolve on the smallest legal
+      // budget. OpenFGA increments resolution depth only when it
+      // dispatches to another object; a rewrite ladder never
+      // exhausts the budget however long it is.
+      buildRewriteChain(3);
       expect(
         await check(
           store,
@@ -896,25 +947,22 @@ describe("check algorithm", () => {
             subjectType: "user",
             subjectId: "alice",
           },
-          { maxDepth: 3 },
+          { maxDepth: 1 },
         ),
       ).toBe(true);
     });
 
+    test("resolves when dispatch depth is exactly at the limit", async () => {
+      // Root plus three dispatches occupies depths 0..3, so the
+      // budget must be 4: the guard trips on `depth === maxDepth`.
+      buildUsersetChain(3);
+      expect(await check(store, groupRequest, { maxDepth: 4 })).toBe(true);
+    });
+
     test("throws DepthExceededError beyond the limit", async () => {
-      buildChain(3);
+      buildUsersetChain(3);
       await expect(
-        check(
-          store,
-          {
-            objectType: "doc",
-            objectId: "1",
-            relation: "lvl0",
-            subjectType: "user",
-            subjectId: "alice",
-          },
-          { maxDepth: 2 },
-        ),
+        check(store, groupRequest, { maxDepth: 3 }),
       ).rejects.toBeInstanceOf(DepthExceededError);
     });
   });
@@ -931,6 +979,35 @@ describe("check algorithm", () => {
           objectType: "doc",
           objectId: "1",
           relation: "a",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      ).rejects.toBeInstanceOf(DepthExceededError);
+    });
+
+    test("long rewrite cycle terminates without the depth guard", async () => {
+      // 40 rewrite hops on doc:1 closing back on lvl0 — longer than
+      // the default budget of 25, but rewrites cost no depth, so
+      // only the resolution path can stop it. It must reject, not
+      // hang. This is the safety argument for charging no depth on
+      // rewrites: one object has a finite set of relations, so the
+      // path Set always closes the loop.
+      const length = 40;
+      for (let i = 0; i < length; i++) {
+        store.relationConfigs.push(
+          makeConfig({
+            objectType: "doc",
+            relation: `lvl${i}`,
+            computedUserset: i === length - 1 ? "lvl0" : `lvl${i + 1}`,
+          }),
+        );
+      }
+
+      await expect(
+        check(store, {
+          objectType: "doc",
+          objectId: "1",
+          relation: "lvl0",
           subjectType: "user",
           subjectId: "alice",
         }),
@@ -1056,20 +1133,47 @@ describe("check algorithm", () => {
 
     test("deep exclusion branch throws instead of granting", async () => {
       // The exclusion chain needs more depth than maxDepth allows.
+      // It has to be a *userset* chain: rewrites of doc:1 cost no
+      // depth, so only dispatch to another object can exhaust the
+      // budget.
       store.relationConfigs.push(
         makeConfig({
           objectType: "doc",
           relation: "editor",
           directlyAssignableTypes: ["user"],
-          excludedBy: "b0",
+          excludedBy: "banned",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned",
+          allowsUsersetSubjects: true,
+        }),
+        makeConfig({
+          objectType: "blocklist",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: true,
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "banned",
+          subjectType: "blocklist",
+          subjectId: "0",
+          subjectRelation: "member",
         }),
       );
       for (let i = 0; i < 5; i++) {
-        store.relationConfigs.push(
-          makeConfig({
-            objectType: "doc",
-            relation: `b${i}`,
-            computedUserset: `b${i + 1}`,
+        store.tuples.push(
+          makeTuple({
+            objectType: "blocklist",
+            objectId: String(i),
+            relation: "member",
+            subjectType: "blocklist",
+            subjectId: String(i + 1),
+            subjectRelation: "member",
           }),
         );
       }
@@ -2182,49 +2286,48 @@ describe("createTsfga client", () => {
 
   describe("maxDepth option", () => {
     test("client-level maxDepth applies to checks", async () => {
+      // One userset hop: group:0 sits at depth 0 and group:1 at
+      // depth 1, so a budget of 1 is exhausted and 2 resolves.
       store.relationConfigs.push(
         makeConfig({
-          objectType: "doc",
-          relation: "a",
-          computedUserset: "b",
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "b",
-          computedUserset: "c",
+          objectType: "group",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: true,
         }),
       );
       store.tuples.push(
         makeTuple({
-          objectType: "doc",
+          objectType: "group",
+          objectId: "0",
+          relation: "member",
+          subjectType: "group",
+          subjectId: "1",
+          subjectRelation: "member",
+        }),
+        makeTuple({
+          objectType: "group",
           objectId: "1",
-          relation: "c",
+          relation: "member",
           subjectType: "user",
           subjectId: "alice",
         }),
       );
+      const request = {
+        objectType: "group",
+        objectId: "0",
+        relation: "member",
+        subjectType: "user",
+        subjectId: "alice",
+      };
 
       const shallow = createTsfga(store, { maxDepth: 1 });
-      await expect(
-        shallow.check({
-          objectType: "doc",
-          objectId: "1",
-          relation: "a",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).rejects.toBeInstanceOf(DepthExceededError);
+      await expect(shallow.check(request)).rejects.toBeInstanceOf(
+        DepthExceededError,
+      );
 
       const deep = createTsfga(store, { maxDepth: 2 });
-      expect(
-        await deep.check({
-          objectType: "doc",
-          objectId: "1",
-          relation: "a",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).toBe(true);
+      expect(await deep.check(request)).toBe(true);
     });
   });
 });

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -56,6 +56,15 @@ bun run turbo:test:conformance
 - `advanced-entitlements` — multi-condition
   entitlements
 
+**Resolution limits and error semantics:**
+- `wide-union` — a node fanning out wider than the
+  default breadth limit of 10
+- `deep-rewrite` — a rewrite ladder deeper than the
+  default depth limit of 25; pins that rewrites of the
+  same object cost no resolution depth
+- `condition-error-siblings` — how a condition error on
+  one branch interacts with its siblings
+
 **Conditions:**
 - `organization-context` — org-scoped conditions
 - `contextual-time-based` — time-window conditions

--- a/tests/conformance/deep-rewrite.test.ts
+++ b/tests/conformance/deep-rewrite.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, describe, test } from "bun:test";
+import { createTsfga, type TsfgaClient } from "@tsfga/core";
+import type { DB } from "@tsfga/kysely";
+import { KyselyTupleStore } from "@tsfga/kysely";
+import type { Kysely } from "kysely";
+import { expectConformance } from "./helpers/conformance.ts";
+import {
+  beginTransaction,
+  destroyDb,
+  getDb,
+  rollbackTransaction,
+} from "./helpers/db.ts";
+import {
+  fgaCreateStore,
+  fgaWriteModel,
+  fgaWriteTuples,
+} from "./helpers/openfga.ts";
+
+// A 30-relation rewrite ladder on a single object, deeper than the
+// default resolution limit of 25, with an exclusion at lvl15 and an
+// intersection at lvl20.
+//
+// OpenFGA increments resolution depth only when it *dispatches* to
+// another object — userset and tuple-to-userset expansion. Rewrites
+// of the same object (computed userset, `but not`, `and`) cost no
+// depth: `checkComputedUserset` calls `ResolveCheck` directly with
+// the comment "No dispatch here, as we don't want to increase
+// resolution depth", and set operations are built on the unchanged
+// request. So this ladder resolves on OpenFGA at the default limit
+// however long it is.
+//
+// tsfga used to charge one depth per rewrite and so threw
+// DepthExceededError here — this fixture is the regression test for
+// that divergence.
+//
+// Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L856
+// Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L415
+
+const DEPTH = 30;
+const EXCLUSION_AT = 15;
+const INTERSECTION_AT = 20;
+
+const uuidMap = new Map<string, string>([
+  ["anne", "00000000-0000-4000-c600-000000000001"],
+  ["bob", "00000000-0000-4000-c600-000000000002"],
+  ["carl", "00000000-0000-4000-c600-000000000003"],
+  ["dave", "00000000-0000-4000-c600-000000000004"],
+  ["1", "00000000-0000-4000-c600-000000000005"],
+]);
+
+function uuid(name: string): string {
+  const id = uuidMap.get(name);
+  if (!id) throw new Error(`No UUID for ${name}`);
+  return id;
+}
+
+describe("Deep Rewrite Ladder Conformance", () => {
+  let db: Kysely<DB>;
+  let storeId: string;
+  let authorizationModelId: string;
+  let tsfgaClient: TsfgaClient;
+
+  beforeAll(async () => {
+    db = getDb();
+    await beginTransaction(db);
+
+    const store = new KyselyTupleStore(db);
+    tsfgaClient = createTsfga(store);
+
+    // === Relation configs: the ladder ===
+    for (let i = 0; i < DEPTH; i++) {
+      const isIntersection = i === INTERSECTION_AT;
+      await tsfgaClient.writeRelationConfig({
+        objectType: "document",
+        relation: `lvl${i}`,
+        directlyAssignableTypes: null,
+        impliedBy: null,
+        computedUserset: isIntersection ? null : `lvl${i + 1}`,
+        tupleToUserset: null,
+        excludedBy: i === EXCLUSION_AT ? "blocked" : null,
+        intersection: isIntersection
+          ? [
+              { type: "computedUserset", relation: `lvl${i + 1}` },
+              { type: "computedUserset", relation: "allowed" },
+            ]
+          : null,
+        allowsUsersetSubjects: false,
+      });
+    }
+    for (const relation of [`lvl${DEPTH}`, "blocked", "allowed"]) {
+      await tsfgaClient.writeRelationConfig({
+        objectType: "document",
+        relation,
+        directlyAssignableTypes: ["user"],
+        impliedBy: null,
+        computedUserset: null,
+        tupleToUserset: null,
+        excludedBy: null,
+        intersection: null,
+        allowsUsersetSubjects: false,
+      });
+    }
+
+    // === Tuples ===
+    // anne reaches the bottom, is permitted and is not blocked.
+    // bob is identical but blocked at lvl15.
+    // carl is identical but fails the intersection at lvl20.
+    // dave has nothing.
+    for (const [subject, relations] of [
+      ["anne", [`lvl${DEPTH}`, "allowed"]],
+      ["bob", [`lvl${DEPTH}`, "allowed", "blocked"]],
+      ["carl", [`lvl${DEPTH}`]],
+    ] as const) {
+      for (const relation of relations) {
+        await tsfgaClient.addTuple({
+          objectType: "document",
+          objectId: uuid("1"),
+          relation,
+          subjectType: "user",
+          subjectId: uuid(subject),
+        });
+      }
+    }
+
+    // Setup OpenFGA
+    storeId = await fgaCreateStore("deep-rewrite-conformance");
+    authorizationModelId = await fgaWriteModel(
+      storeId,
+      "./deep-rewrite/model.dsl",
+    );
+    await fgaWriteTuples(
+      storeId,
+      "./deep-rewrite/tuples.yaml",
+      authorizationModelId,
+      uuidMap,
+    );
+  });
+
+  afterAll(async () => {
+    await rollbackTransaction(db);
+    await destroyDb();
+  });
+
+  test("1: 30 rewrites resolve at the default depth limit", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "lvl0",
+        subjectType: "user",
+        subjectId: uuid("anne"),
+      },
+      true,
+    );
+  });
+
+  test("2: exclusion partway up the ladder denies", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "lvl0",
+        subjectType: "user",
+        subjectId: uuid("bob"),
+      },
+      false,
+    );
+  });
+
+  test("3: intersection partway up the ladder denies", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "lvl0",
+        subjectType: "user",
+        subjectId: uuid("carl"),
+      },
+      false,
+    );
+  });
+
+  test("4: subject with no tuples at all is denied", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: "lvl0",
+        subjectType: "user",
+        subjectId: uuid("dave"),
+      },
+      false,
+    );
+  });
+
+  test("5: an intermediate rung resolves the same way", async () => {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation: `lvl${EXCLUSION_AT}`,
+        subjectType: "user",
+        subjectId: uuid("anne"),
+      },
+      true,
+    );
+  });
+});

--- a/tests/conformance/deep-rewrite/model.dsl
+++ b/tests/conformance/deep-rewrite/model.dsl
@@ -1,0 +1,40 @@
+model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define lvl0: lvl1
+    define lvl1: lvl2
+    define lvl2: lvl3
+    define lvl3: lvl4
+    define lvl4: lvl5
+    define lvl5: lvl6
+    define lvl6: lvl7
+    define lvl7: lvl8
+    define lvl8: lvl9
+    define lvl9: lvl10
+    define lvl10: lvl11
+    define lvl11: lvl12
+    define lvl12: lvl13
+    define lvl13: lvl14
+    define lvl14: lvl15
+    define lvl15: lvl16 but not blocked
+    define lvl16: lvl17
+    define lvl17: lvl18
+    define lvl18: lvl19
+    define lvl19: lvl20
+    define lvl20: lvl21 and allowed
+    define lvl21: lvl22
+    define lvl22: lvl23
+    define lvl23: lvl24
+    define lvl24: lvl25
+    define lvl25: lvl26
+    define lvl26: lvl27
+    define lvl27: lvl28
+    define lvl28: lvl29
+    define lvl29: lvl30
+    define lvl30: [user]
+    define blocked: [user]
+    define allowed: [user]

--- a/tests/conformance/deep-rewrite/tuples.yaml
+++ b/tests/conformance/deep-rewrite/tuples.yaml
@@ -1,0 +1,22 @@
+# anne: at the bottom of the ladder, permitted, not blocked.
+# bob:  same, but blocked at lvl15.
+# carl: same, but fails the intersection at lvl20.
+# dave: nothing at all.
+- user: user:anne
+  relation: lvl30
+  object: document:1
+- user: user:anne
+  relation: allowed
+  object: document:1
+- user: user:bob
+  relation: lvl30
+  object: document:1
+- user: user:bob
+  relation: allowed
+  object: document:1
+- user: user:bob
+  relation: blocked
+  object: document:1
+- user: user:carl
+  relation: lvl30
+  object: document:1


### PR DESCRIPTION
tsfga exhausted the resolution budget earlier than OpenFGA on any
model with stacked rewrites, throwing DepthExceededError where
upstream resolves. It was reachable at the default limit of 25.

OpenFGA increments resolution depth in exactly one place —
`dispatch`, which is called only when expanding a userset or a
tuple-to-userset child, i.e. when moving to another object.
Rewrites of the same object cost nothing: `checkComputedUserset`
recurses into `ResolveCheck` directly, with the comment "No
dispatch here, as we don't want to increase resolution depth",
and union / intersection / exclusion operands are all built on
the unchanged request.

tsfga instead charged a depth for `impliedBy`, `computedUserset`,
`excludedBy` and intersection operands as well, and guarded with
`depth > maxDepth` where upstream errors on
`Depth == maxResolutionDepth`. Both are fixed here: only steps 2
and 5 increment, and the guard is now `depth >= maxDepth`, so a
budget of maxDepth admits a root node plus maxDepth - 1
dispatches.

Removing the increment does not remove the termination argument.
A rewrite keeps the object fixed and only varies the relation, so
the keys it can reach are finite and the resolution path Set
closes every loop; only userset and TTU expansion can introduce
new objects, and those still cost depth. A 40-hop rewrite cycle
at the default budget is covered by a new core test to keep that
honest.

Behavior-visible but not an API change, so no shim question
arises; CHANGELOG entry added under Unreleased.

The core depth tests encoded the old counting model and had to be
re-derived rather than merely adjusted: three of them proved
exhaustion using computed-userset ladders, which now cost no
depth at all. They are rebuilt on userset chains, which do
dispatch, and a new test pins the zero-cost rewrite ladder
directly. The regression test that matters is the conformance
fixture `deep-rewrite`: a 30-relation ladder with an exclusion at
lvl15 and an intersection at lvl20, which OpenFGA resolves and
tsfga threw on before this change.

Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L383
Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L415
Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L856
Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/default_resolver.go#L289
