### PR TITLE
Resolve cycles as false instead of erroring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,15 @@ export async function check(
   cost none, matching OpenFGA, which increments resolution depth only
   in `dispatch`. Unbounded rewrite recursion is prevented by the cycle
   path, not by the depth budget
+- **A cycle is not an error.** Revisiting a node on the resolution path
+  resolves `false`; only depth exhaustion throws. Internally the node
+  result is `{allowed, cycleDetected}`, because the set operators read
+  a cycle-truncated `false` differently from a plain one — on the
+  subtract side of `excludedBy` a cycle *denies*, so collapsing it to
+  `false` would fail open. The flag is internal, exactly as OpenFGA's
+  `CycleDetected` is absent from the wire response. See
+  `packages/core/README.md` for the table and for the one known
+  divergence (OpenFGA's recursive-relation resolvers)
 
 ## CEL Conditions (`packages/core/src/conditions.ts`)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,33 @@ releases may contain breaking changes).
 
 ## Unreleased
 
+### Breaking changes
+
+- **A cycle in the resolution path no longer throws.** Revisiting
+  a node used to raise `DepthExceededError`, the same error as
+  depth exhaustion. It now resolves `false`, and `check()` returns
+  `false` to the caller. OpenFGA errors only on depth exhaustion;
+  a cycle is `Allowed:false` with an internal `CycleDetected`
+  flag. Callers that catch `DepthExceededError` to detect a cyclic
+  model will no longer see it — depth exhaustion still throws, and
+  is now the only thing that does.
+
+  Internally the flag is tracked rather than collapsed into a
+  plain `false`, because the set operators read the two
+  differently. Most sharply: on the subtract side of `but not` a
+  cycle *denies*, so `base:true but not subtract:cycle` is
+  `false`. Treating a cycle as an ordinary `false` there would
+  grant — a fail-open. Like OpenFGA, the flag is not exposed on
+  the public result.
+
+  Known divergence, documented in the README: OpenFGA has
+  dedicated resolvers for recursive relation shapes
+  (`define member: [user, group#member]`, or a TTU recursing on
+  its own relation), which resolve a data loop to a definitive
+  `false` with no flag. tsfga reports indeterminacy there. The
+  only case where that is observable is the subtract side of a
+  `but not`, where OpenFGA grants and tsfga denies.
+
 ### Changed
 
 - **Only dispatches to another object spend the depth budget.**

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,18 +83,24 @@ bounded instead by cycle detection, since one object has a
 finite set of relations. A budget of `maxDepth` admits a root
 node plus `maxDepth - 1` dispatches.
 
-- When the budget is exhausted, or when the resolution path
-  revisits a node it already contains (a cyclic model),
-  `check()` throws `DepthExceededError` — mirroring OpenFGA's
-  "resolution too complex" error. Prior to 0.3.0 exhaustion
-  silently resolved to `false`, which could fail open: a
-  truncated `excludedBy` sub-check read as "not excluded" and
-  granted access.
+- When the budget is exhausted, `check()` throws
+  `DepthExceededError` — mirroring OpenFGA's "resolution too
+  complex" error. Prior to 0.3.0 exhaustion silently resolved to
+  `false`, which could fail open: a truncated `excludedBy`
+  sub-check read as "not excluded" and granted access.
+- **A cycle is not an error.** When the resolution path revisits
+  a node it already contains, that subtree resolves `false`, and
+  `check()` returns `false` to the caller. This matches OpenFGA,
+  which errors only on depth exhaustion and returns
+  `Allowed:false` with an internal `CycleDetected` flag for a
+  cycle. tsfga tracks the same flag internally; like OpenFGA it
+  is not exposed on the public result. See "Cycles and
+  indeterminacy" below for why it is not simply a `false`.
 - Union-style branches (direct, userset, implied_by, computed
   userset, tuple-to-userset) are resolved concurrently: a
   branch that resolves `true` wins even if a sibling branch
-  threw `DepthExceededError`. If no branch grants and at least
-  one errored, the error propagates.
+  threw `DepthExceededError` or was truncated by a cycle. If no
+  branch grants and at least one errored, the error propagates.
 - Exclusion (`excludedBy`) and intersection branches fail
   closed: an errored branch never counts as satisfied or as
   not-excluded. A definitive deny still short-circuits past a
@@ -105,6 +111,43 @@ node plus `maxDepth - 1` dispatches.
   error (`ConditionEvaluationError`), not an unmet condition —
   matching OpenFGA's check behavior. A silently-unmet
   condition would fail open through an exclusion branch.
+
+## Cycles and indeterminacy
+
+A cycle-truncated `false` means *no answer was reached*, not
+*access is denied*, and the set operators read the difference:
+
+| Position | A cycled branch behaves like |
+|---|---|
+| union branch | `false` — a granting sibling still wins |
+| intersection operand | `false` — denies, it cannot be shown to hold |
+| base of `but not` | `false` — denies |
+| **subtract of `but not`** | **`true` — denies** |
+
+The last row is the one that matters. Implementing "a cycle is
+just `false`" makes `base:true but not subtract:cycle` grant,
+because the truncated exclusion reads as "not excluded". OpenFGA
+denies, and so does tsfga.
+
+### Known divergence: recursive relations
+
+OpenFGA has dedicated resolvers for *recursive* relation shapes
+— a relation assignable to a userset of itself
+(`define member: [user, group#member]`), or a TTU that recurses
+on its own relation (`define viewer: [user] or viewer from
+parent`). Those walk the reachable set iteratively, so a loop in
+the data resolves to a definitive `false` with no cycle flag.
+tsfga has a single recursive resolver and reports indeterminacy
+there instead.
+
+The only observable consequence is the subtract side of a
+`but not`: given a looping recursive relation on the subtract
+side and a base that grants, OpenFGA returns `true` and tsfga
+returns `false`. Every other position agrees, because a plain
+`false` and a cycled `false` behave identically there. tsfga is
+the more conservative of the two — it denies where OpenFGA
+grants — but this is a divergence, not a design choice, and it
+will close if the recursive resolvers are implemented.
 
 ## Breadth limits
 

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -15,6 +15,73 @@ import type {
 type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
 
 /**
+ * Internal result of resolving one node.
+ *
+ * `cycleDetected` marks a `false` that is an *absence of an
+ * answer* rather than a denial: the resolution path looped back
+ * on itself and the subtree was truncated. It matters because the
+ * set operators treat it differently from a plain `false` — most
+ * sharply on the subtract side of an exclusion, where a cycle
+ * denies rather than failing to exclude.
+ *
+ * It stays internal. Upstream's equivalent lives in
+ * `ResolveCheckResponseMetadata`, reaches the command layer's
+ * `CheckResult`, and is not a field of the wire `CheckResponse` —
+ * so it is not exposed on tsfga's `check()` return either.
+ *
+ * Never mutated; the shared constants below are safe to alias.
+ */
+export interface CheckResult {
+  allowed: boolean;
+  cycleDetected: boolean;
+}
+
+const DENIED: CheckResult = { allowed: false, cycleDetected: false };
+const GRANTED: CheckResult = { allowed: true, cycleDetected: false };
+const CYCLE: CheckResult = { allowed: false, cycleDetected: true };
+
+/**
+ * How a set operator folds its branches. Union and intersection
+ * are not quite duals once cycles are in play, so each supplies
+ * its own rule rather than sharing a `shortCircuitOn` flag.
+ */
+export interface Reducer {
+  /** Seed, and the result if every branch ran without deciding. */
+  readonly initial: CheckResult;
+  /** Non-null ends the node immediately with that result. */
+  decide(result: CheckResult): CheckResult | null;
+  /** Fold a non-deciding branch into the running result. */
+  accumulate(acc: CheckResult, result: CheckResult): CheckResult;
+}
+
+/**
+ * Union: the first grant wins and is returned verbatim, so a
+ * truncated sibling is forgotten. Otherwise a cycle anywhere makes
+ * the whole `false` indeterminate. An errored branch neither
+ * decides nor contributes a flag, but does beat a cycle-`false` on
+ * exhaustion — `true` > error > cycle > `false`.
+ */
+export const UNION_REDUCER: Reducer = {
+  initial: DENIED,
+  decide: (result) => (result.allowed ? result : null),
+  accumulate: (acc, result) => (result.cycleDetected ? CYCLE : acc),
+};
+
+/**
+ * Intersection: a cycle is as fatal as a plain `false`, since an
+ * operand that could not be resolved cannot be shown to hold. The
+ * deciding operand's flag rides out with the denial.
+ */
+export const INTERSECTION_REDUCER: Reducer = {
+  initial: GRANTED,
+  decide: (result) =>
+    result.cycleDetected || !result.allowed
+      ? { allowed: false, cycleDetected: result.cycleDetected }
+      : null,
+  accumulate: (acc) => acc,
+};
+
+/**
  * Recursive check algorithm with support for:
  * - Direct tuple check + wildcard
  * - Userset expansion
@@ -26,10 +93,30 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  *
  * Error semantics:
  * - Throws DepthExceededError when the recursion budget
- *   (`options.maxDepth`, default 25) is exhausted or a cycle is
- *   detected in the resolution path. Exhaustion is never converted
- *   to `false`: inside an exclusion or intersection branch that
- *   would fail open.
+ *   (`options.maxDepth`, default 25) is exhausted. Exhaustion is
+ *   never converted to `false`: inside an exclusion or
+ *   intersection branch that would fail open.
+ * - A cycle in the resolution path is *not* an error. The looping
+ *   subtree resolves `false` carrying an internal indeterminacy
+ *   flag, matching OpenFGA, which errors only on depth exhaustion
+ *   and returns `Allowed:false` with `CycleDetected:true` for a
+ *   cycle. The flag is not merely a `false`: on the subtract side
+ *   of an exclusion it denies, so `base:true butnot sub:cycle` is
+ *   `false` rather than a grant.
+ * - Within union-style resolution (steps 1-5), a branch that
+ *   resolves `true` wins even if a sibling branch threw
+ *   DepthExceededError or was truncated by a cycle. If no branch
+ *   resolves `true` and at least one errored, the error
+ *   propagates.
+ * - Exclusion and intersection fail closed — an errored branch
+ *   never counts as satisfied or as not-excluded — but a
+ *   definitive deny short-circuits past a sibling error, matching
+ *   OpenFGA: an intersection operand resolving `false`, or an
+ *   exclusion branch resolving `true`, denies even when the other
+ *   branch errored.
+ * - Contextual tuples are validated against relation configs
+ *   exactly like `addTuple` (RelationConfigNotFoundError,
+ *   InvalidSubjectTypeError, UsersetNotAllowedError).
  *
  * Depth accounting: only steps that move to a *different object*
  * — userset expansion and tuple-to-userset expansion — cost
@@ -41,19 +128,6 @@ type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
  * that "we don't want to increase resolution depth". Rewrite
  * recursion is bounded by the cycle path instead: the relation
  * set of one object is finite, so it always terminates.
- * - Within union-style resolution (steps 1-5), a branch that
- *   resolves `true` wins even if a sibling branch threw
- *   DepthExceededError. If no branch resolves `true` and at least
- *   one errored, the error propagates.
- * - Exclusion and intersection fail closed — an errored branch
- *   never counts as satisfied or as not-excluded — but a
- *   definitive deny short-circuits past a sibling error, matching
- *   OpenFGA: an intersection operand resolving `false`, or an
- *   exclusion branch resolving `true`, denies even when the other
- *   branch errored.
- * - Contextual tuples are validated against relation configs
- *   exactly like `addTuple` (RelationConfigNotFoundError,
- *   InvalidSubjectTypeError, UsersetNotAllowedError).
  *
  * Concurrency: branches of one resolution node run concurrently,
  * bounded by `options.maxBreadth` (default 10, matching OpenFGA's
@@ -111,14 +185,24 @@ export async function check(
     );
   }
 
-  return checkNode(effectiveStore, request, maxDepth, maxBreadth, 0, new Set());
+  const result = await checkNode(
+    effectiveStore,
+    request,
+    maxDepth,
+    maxBreadth,
+    0,
+    new Set(),
+  );
+  // The indeterminacy flag is internal; a cycle at the root is an
+  // ordinary deny to the caller, as it is on OpenFGA's wire.
+  return result.allowed;
 }
 
 /**
  * Resolve one node of the check graph. Tracks the current
  * resolution path in `path` (keys of `objectType:objectId#relation`
- * — the subject is constant per request) so cycles throw
- * DepthExceededError instead of silently resolving.
+ * — the subject is constant per request) so a revisit truncates
+ * the subtree instead of recursing forever.
  */
 async function checkNode(
   store: TupleStore,
@@ -127,7 +211,7 @@ async function checkNode(
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
-): Promise<boolean> {
+): Promise<CheckResult> {
   // `depth` counts dispatches already made, so the budget is spent
   // once it reaches maxDepth — OpenFGA errors on
   // `Depth == maxResolutionDepth`, before resolving the node.
@@ -137,7 +221,9 @@ async function checkNode(
 
   const key = `${request.objectType}:${request.objectId}#${request.relation}`;
   if (path.has(key)) {
-    throw new DepthExceededError(`cycle detected at ${key}`);
+    // Not an error: an indeterminate `false` that the set
+    // operators above interpret for themselves.
+    return CYCLE;
   }
   const visited = new Set(path);
   visited.add(key);
@@ -157,7 +243,7 @@ async function checkNode(
   );
 
   // Base resolution: intersection replaces steps 1-5 when present
-  const resolveBase = (): Promise<boolean> =>
+  const resolveBase = (): Promise<CheckResult> =>
     config?.intersection
       ? checkIntersection(
           store,
@@ -187,6 +273,14 @@ async function checkNode(
   // branch denies even when the base errored. Errors otherwise
   // fail closed: a base grant with an errored exclusion branch
   // propagates the error rather than granting.
+  //
+  // The two sides read a cycle differently, and the asymmetry is
+  // the whole reason indeterminacy is tracked rather than folded
+  // into `false`. On the base side a cycle behaves like `false` —
+  // nothing was established, so nothing is granted. On the
+  // subtract side it behaves like `true` — the exclusion could not
+  // be ruled out, so access is denied. Treating a cycle as a plain
+  // `false` would grant `base:true butnot sub:cycle`, a fail-open.
   if (config?.excludedBy) {
     const excludedBy = config.excludedBy;
     const [baseResult, exclusionResult] = await Promise.allSettled([
@@ -202,19 +296,28 @@ async function checkNode(
         visited,
       ),
     ]);
-    if (exclusionResult.status === "fulfilled" && exclusionResult.value) {
-      return false;
+    if (
+      exclusionResult.status === "fulfilled" &&
+      (exclusionResult.value.cycleDetected || exclusionResult.value.allowed)
+    ) {
+      return {
+        allowed: false,
+        cycleDetected: exclusionResult.value.cycleDetected,
+      };
+    }
+    if (
+      baseResult.status === "fulfilled" &&
+      (baseResult.value.cycleDetected || !baseResult.value.allowed)
+    ) {
+      return { allowed: false, cycleDetected: baseResult.value.cycleDetected };
     }
     if (baseResult.status === "rejected") {
       throw baseResult.reason;
     }
-    if (!baseResult.value) {
-      return false;
-    }
     if (exclusionResult.status === "rejected") {
       throw exclusionResult.reason;
     }
-    return true;
+    return GRANTED;
   }
 
   return resolveBase();
@@ -253,6 +356,21 @@ function readNodeTuples(
 }
 
 /**
+ * A tuple's condition as a union branch. Condition evaluation can
+ * only grant or deny — it never reaches another node, so it can
+ * never be indeterminate.
+ */
+async function evaluateCondition(
+  store: TupleStore,
+  tuple: Tuple,
+  context: Record<string, unknown> | undefined,
+): Promise<CheckResult> {
+  return (await evaluateTupleCondition(store, tuple, context))
+    ? GRANTED
+    : DENIED;
+}
+
+/**
  * Base check: steps 1-5 without exclusion or intersection handling.
  */
 async function checkBase(
@@ -264,33 +382,31 @@ async function checkBase(
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
-): Promise<boolean> {
+): Promise<CheckResult> {
   const [directTuple, wildcardTuple, usersetTuples] = await reads;
 
   // Steps 1/1b: an unconditioned direct or wildcard hit answers
   // immediately, before any sub-check is launched
   if (directTuple && !directTuple.conditionName) {
-    return true;
+    return GRANTED;
   }
   if (wildcardTuple && !wildcardTuple.conditionName) {
-    return true;
+    return GRANTED;
   }
 
   // Collect all sub-check handlers for concurrent resolution
-  const handlers: Array<() => Promise<boolean>> = [];
+  const handlers: Array<() => Promise<CheckResult>> = [];
 
   // Conditioned direct/wildcard hits race as union branches so
   // their condition evaluation (a possible condition-definition
   // fetch) does not block the fanout below. Union semantics
   // apply: a sibling `true` beats a condition error.
   if (directTuple) {
-    handlers.push(() =>
-      evaluateTupleCondition(store, directTuple, request.context),
-    );
+    handlers.push(() => evaluateCondition(store, directTuple, request.context));
   }
   if (wildcardTuple) {
     handlers.push(() =>
-      evaluateTupleCondition(store, wildcardTuple, request.context),
+      evaluateCondition(store, wildcardTuple, request.context),
     );
   }
 
@@ -301,7 +417,7 @@ async function checkBase(
     const relation = userset.subjectRelation;
     handlers.push(async () => {
       if (!(await evaluateTupleCondition(store, userset, request.context))) {
-        return false;
+        return DENIED;
       }
       return checkNode(
         store,
@@ -371,7 +487,7 @@ async function checkBase(
       );
 
       // Collect all linked-tuple check handlers
-      const ttuHandlers: Array<() => Promise<boolean>> = [];
+      const ttuHandlers: Array<() => Promise<CheckResult>> = [];
       for (const [i, { computedUserset }] of ttuEntries.entries()) {
         const linkedTuples = linkedResults[i] ?? [];
         for (const linked of linkedTuples) {
@@ -414,7 +530,7 @@ async function checkIntersection(
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
-): Promise<boolean> {
+): Promise<CheckResult> {
   const operands = config.intersection;
   // An intersection with no operands would resolve vacuously true,
   // granting access to every subject on a malformed config.
@@ -427,7 +543,7 @@ async function checkIntersection(
     );
   }
 
-  const handlers: Array<() => Promise<boolean>> = [];
+  const handlers: Array<() => Promise<CheckResult>> = [];
 
   for (const operand of operands) {
     if (operand.type === "direct") {
@@ -463,7 +579,7 @@ async function checkIntersection(
           request.objectId,
           operand.tupleset,
         );
-        const ttuHandlers: Array<() => Promise<boolean>> = [];
+        const ttuHandlers: Array<() => Promise<CheckResult>> = [];
         for (const linked of linkedTuples) {
           ttuHandlers.push(() =>
             checkNode(
@@ -493,41 +609,46 @@ async function checkIntersection(
 
 /**
  * Run handlers with at most `maxBreadth` in flight, short-circuit
- * on first true. A `true` result wins even when sibling branches
- * rejected (e.g. with DepthExceededError). When no handler resolves
- * true, rejects with the first error if any handler rejected;
- * resolves false otherwise. Handlers still queued when the union
- * settles are never started.
+ * on the first grant. A grant wins even when sibling branches
+ * rejected (e.g. with DepthExceededError) or were truncated by a
+ * cycle. When no handler grants, rejects with the first error if
+ * any handler rejected; otherwise resolves `false`, flagged
+ * indeterminate if any branch hit a cycle. Handlers still queued
+ * when the union settles are never started.
  */
 function resolveUnion(
-  handlers: Array<() => Promise<boolean>>,
+  handlers: Array<() => Promise<CheckResult>>,
   maxBreadth: number,
-): Promise<boolean> {
-  return resolveShortCircuit(handlers, maxBreadth, true);
+): Promise<CheckResult> {
+  return resolveShortCircuit(handlers, maxBreadth, UNION_REDUCER);
 }
 
 /**
  * Run handlers with at most `maxBreadth` in flight, short-circuit
- * on first false — a definitive false wins even when a sibling
- * operand errored, matching OpenFGA's intersection. Resolves true
- * when all return true. When no operand resolves false and at
- * least one errored, rejects with the first error (fail closed:
- * an errored operand never counts as satisfied). Handlers still
- * queued when the intersection settles are never started.
+ * on the first operand that fails to hold — a definitive false, or
+ * a cycle-truncated operand, wins even when a sibling operand
+ * errored, matching OpenFGA's intersection. Resolves true when all
+ * operands hold. When none fails and at least one errored, rejects
+ * with the first error (fail closed: an errored operand never
+ * counts as satisfied). Handlers still queued when the
+ * intersection settles are never started.
  */
 function resolveIntersection(
-  handlers: Array<() => Promise<boolean>>,
+  handlers: Array<() => Promise<CheckResult>>,
   maxBreadth: number,
-): Promise<boolean> {
-  return resolveShortCircuit(handlers, maxBreadth, false);
+): Promise<CheckResult> {
+  return resolveShortCircuit(handlers, maxBreadth, INTERSECTION_REDUCER);
 }
 
 /**
- * Bounded pull-model combinator shared by union and intersection —
- * duals of each other: union short-circuits on `true` and resolves
- * `false` on exhaustion; intersection short-circuits on `false`
- * and resolves `true` on exhaustion. Mirrors OpenFGA's reducers,
- * which take the breadth limit as their concurrency bound.
+ * Bounded pull-model combinator shared by union and intersection.
+ * They are near-duals — union short-circuits on a grant and
+ * resolves `false` on exhaustion, intersection short-circuits on a
+ * non-grant and resolves `true` — but not exactly, because a
+ * cycle-truncated branch decides an intersection and does not
+ * decide a union. The `reducer` supplies that difference. Mirrors
+ * OpenFGA's reducers, which take the breadth limit as their
+ * concurrency bound.
  *
  * Handlers launch in array order while fewer than `maxBreadth` are
  * in flight; each settlement pulls the next queued handler. Once
@@ -535,32 +656,34 @@ function resolveIntersection(
  * ignored on completion, and their rejections are consumed by the
  * callbacks attached at launch — no unhandled rejections. On
  * exhaustion with no decisive result, one recorded error (the
- * first by completion order) propagates; otherwise the
- * non-short-circuit value resolves. Which branch's error surfaces
- * when several fail is scheduling-dependent, as it is in OpenFGA
- * (whose union keeps the last-completed error instead).
+ * first by completion order) propagates — errors outrank the
+ * accumulated value, so a cycle-flagged `false` never masks a
+ * failure. Which branch's error surfaces when several fail is
+ * scheduling-dependent, as it is in OpenFGA (whose union keeps the
+ * last-completed error instead).
  *
  * Exported for direct unit tests only; not part of the public
  * package API (not re-exported from index.ts).
  */
 export function resolveShortCircuit(
-  handlers: Array<() => Promise<boolean>>,
+  handlers: Array<() => Promise<CheckResult>>,
   maxBreadth: number,
-  shortCircuitOn: boolean,
-): Promise<boolean> {
+  reducer: Reducer,
+): Promise<CheckResult> {
   return new Promise((resolve, reject) => {
     let next = 0;
     let active = 0;
     let settled = false;
     let firstError: unknown;
     let hasError = false;
+    let accumulated = reducer.initial;
 
     const settleExhausted = () => {
       settled = true;
       if (hasError) {
         reject(firstError);
       } else {
-        resolve(!shortCircuitOn);
+        resolve(accumulated);
       }
     };
 
@@ -579,7 +702,7 @@ export function resolveShortCircuit(
         next++;
         if (!handler) continue;
         active++;
-        let branch: Promise<boolean>;
+        let branch: Promise<CheckResult>;
         try {
           branch = handler();
         } catch (error) {
@@ -596,11 +719,13 @@ export function resolveShortCircuit(
         branch.then(
           (result) => {
             if (settled) return;
-            if (result === shortCircuitOn) {
+            const decided = reducer.decide(result);
+            if (decided) {
               settled = true;
-              resolve(shortCircuitOn);
+              resolve(decided);
               return;
             }
+            accumulated = reducer.accumulate(accumulated, result);
             onHandlerDone();
           },
           (error) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,9 +15,10 @@ export interface TsfgaClient {
    * Check whether a subject has a relation on an object.
    *
    * @throws DepthExceededError when the recursion budget
-   *   (`maxDepth`, default 25) is exhausted or a cycle is detected
-   *   in the resolution path. Exhaustion never resolves to `false`
-   *   — a truncated exclusion branch must not grant access.
+   *   (`maxDepth`, default 25) is exhausted. Exhaustion never
+   *   resolves to `false` — a truncated exclusion branch must not
+   *   grant access. A cycle in the resolution path is not an
+   *   error: it resolves `false`, matching OpenFGA.
    * @throws RelationConfigNotFoundError, InvalidSubjectTypeError,
    *   or UsersetNotAllowedError when a contextual tuple fails the
    *   same validation `addTuple` applies.

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { check, resolveShortCircuit } from "../src/check.ts";
-import {
-  ConditionNotFoundError,
-  DepthExceededError,
-  TsfgaError,
-} from "../src/errors.ts";
+import { ConditionNotFoundError, TsfgaError } from "../src/errors.ts";
 import type {
   ConditionDefinition,
   RelationConfig,
   Tuple,
 } from "../src/types.ts";
+import {
+  ConfigErrorStore,
+  StoreReadFailure,
+} from "./helpers/erroring-store.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
 function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
@@ -103,10 +103,11 @@ class GatedConfigStore extends MockTupleStore {
 }
 
 /**
- * Delays condition-definition lookups so a conditioned branch
- * errors late while a cycling sibling errors immediately.
+ * Slow condition lookups on top of the config-read failure, so one
+ * store can host a slow-failing branch and a fast-failing one with
+ * distinguishable error classes.
  */
-class SlowConditionLookupStore extends MockTupleStore {
+class SlowConditionLookupStore extends ConfigErrorStore {
   override async findConditionDefinition(
     name: string,
   ): Promise<ConditionDefinition | null> {
@@ -344,20 +345,19 @@ describe("bounded launch behavior", () => {
 });
 
 describe("error semantics under bounded breadth", () => {
-  /** viewer implied by [looper, ...rest]; looper cycles back. */
+  /**
+   * viewer implied by [broken, ...rest], where `broken`'s config
+   * read rejects. The error source is a store failure rather than
+   * a cycle: what is under test is how the bounded combinator
+   * treats *an* erroring branch, which is independent of cycle
+   * semantics.
+   */
   function erringStore(rest: string[], granted: string[]): MockTupleStore {
-    const store = seedUnion(new MockTupleStore(), rest, granted);
+    const store = seedUnion(new ConfigErrorStore(["broken"]), rest, granted);
     const viewer = store.relationConfigs.find((c) => c.relation === "viewer");
     if (viewer) {
-      viewer.impliedBy = ["looper", ...rest];
+      viewer.impliedBy = ["broken", ...rest];
     }
-    store.relationConfigs.push(
-      makeConfig({
-        objectType: "doc",
-        relation: "looper",
-        impliedBy: ["viewer"],
-      }),
-    );
     return store;
   }
 
@@ -365,7 +365,7 @@ describe("error semantics under bounded breadth", () => {
     const store = erringStore(["r2"], []);
     await expect(
       check(store, viewerRequest, { maxBreadth: 1 }),
-    ).rejects.toBeInstanceOf(DepthExceededError);
+    ).rejects.toBeInstanceOf(StoreReadFailure);
   });
 
   test("a later true beats an earlier error at breadth 1", async () => {
@@ -375,20 +375,15 @@ describe("error semantics under bounded breadth", () => {
   });
 
   test("false intersection operand beats an errored sibling at breadth 1", async () => {
-    const store = new MockTupleStore();
+    const store = new ConfigErrorStore(["broken"]);
     store.relationConfigs.push(
       makeConfig({
         objectType: "doc",
         relation: "access",
         intersection: [
-          { type: "computedUserset", relation: "looper" },
+          { type: "computedUserset", relation: "broken" },
           { type: "computedUserset", relation: "member" },
         ],
-      }),
-      makeConfig({
-        objectType: "doc",
-        relation: "looper",
-        impliedBy: ["access"],
       }),
       makeConfig({
         objectType: "doc",
@@ -405,12 +400,14 @@ describe("error semantics under bounded breadth", () => {
   });
 
   test("losing branch that errors after a win still resolves true", async () => {
-    const store = new MockTupleStore();
+    // `slowbroken` rejects 20ms in, well after the granted branch
+    // has already won the union.
+    const store = new ConfigErrorStore(["slowbroken"], 20);
     store.relationConfigs.push(
       makeConfig({
         objectType: "doc",
         relation: "viewer",
-        impliedBy: ["granted", "slowlooper"],
+        impliedBy: ["granted", "slowbroken"],
       }),
       makeConfig({
         objectType: "doc",
@@ -427,18 +424,6 @@ describe("error semantics under bounded breadth", () => {
         subjectId: "anne",
       }),
     );
-    const original = store.findRelationConfig.bind(store);
-    store.findRelationConfig = async (objectType, relation) => {
-      if (relation === "slowlooper") {
-        await delay(20);
-        return makeConfig({
-          objectType: "doc",
-          relation: "slowlooper",
-          impliedBy: ["viewer"],
-        });
-      }
-      return original(objectType, relation);
-    };
 
     const result = await check(store, viewerRequest, { maxBreadth: 2 });
     expect(result).toBe(true);
@@ -478,15 +463,15 @@ describe("adversarial-review regressions", () => {
   test("surfaced error class is pinned to array order at breadth 1", async () => {
     // Two failing branches with different error classes: slowerr
     // (first in array, ConditionNotFoundError after a delayed
-    // condition lookup) and fasterr (cycle, DepthExceededError
-    // immediately). The boolean/reject status is breadth-invariant
-    // but the surfaced class is completion-ordered: breadth 1
-    // completes in array order, unbounded lets the fast error
-    // record first. Pinned as accepted, upstream-matching
-    // nondeterminism (OpenFGA's union keeps a completion-ordered
-    // error too).
+    // condition lookup) and fasterr (StoreReadFailure from the
+    // config read, immediately). The boolean/reject status is
+    // breadth-invariant but the surfaced class is
+    // completion-ordered: breadth 1 completes in array order,
+    // unbounded lets the fast error record first. Pinned as
+    // accepted, upstream-matching nondeterminism (OpenFGA's union
+    // keeps a completion-ordered error too).
     function makeStore(): MockTupleStore {
-      const store = new SlowConditionLookupStore();
+      const store = new SlowConditionLookupStore(["fasterr"]);
       store.relationConfigs.push(
         makeConfig({
           objectType: "doc",
@@ -497,11 +482,6 @@ describe("adversarial-review regressions", () => {
           objectType: "doc",
           relation: "slowerr",
           directlyAssignableTypes: ["user"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "fasterr",
-          impliedBy: ["viewer"],
         }),
       );
       store.tuples.push(
@@ -524,7 +504,7 @@ describe("adversarial-review regressions", () => {
       check(makeStore(), viewerRequest, {
         maxBreadth: Number.POSITIVE_INFINITY,
       }),
-    ).rejects.toBeInstanceOf(DepthExceededError);
+    ).rejects.toBeInstanceOf(StoreReadFailure);
   });
 });
 

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { check, resolveShortCircuit } from "../src/check.ts";
+import {
+  type CheckResult,
+  check,
+  INTERSECTION_REDUCER,
+  resolveShortCircuit,
+  UNION_REDUCER,
+} from "../src/check.ts";
 import { ConditionNotFoundError, TsfgaError } from "../src/errors.ts";
 import type {
   ConditionDefinition,
@@ -516,49 +522,105 @@ describe("resolveShortCircuit hardening", () => {
 
   class SyncBoom extends Error {}
 
+  const grant = async (): Promise<CheckResult> => ({
+    allowed: true,
+    cycleDetected: false,
+  });
+  const deny = async (): Promise<CheckResult> => ({
+    allowed: false,
+    cycleDetected: false,
+  });
+  const thrower = (): Promise<CheckResult> => {
+    throw new SyncBoom("sync boom");
+  };
+
   test("array holes cannot stall the combinator", async () => {
     // Before hardening, a hole consumed on the refill path could
     // exhaust the array with nothing in flight and never settle.
-    const handlers: Array<() => Promise<boolean>> = [];
-    handlers[0] = async () => false;
-    handlers[2] = async () => false;
-    expect(await resolveShortCircuit(handlers, 1, true)).toBe(false);
+    const handlers: Array<() => Promise<CheckResult>> = [];
+    handlers[0] = deny;
+    handlers[2] = deny;
+    expect(
+      (await resolveShortCircuit(handlers, 1, UNION_REDUCER)).allowed,
+    ).toBe(false);
 
-    const onlyHoles: Array<() => Promise<boolean>> = [];
+    const onlyHoles: Array<() => Promise<CheckResult>> = [];
     onlyHoles.length = 3;
-    expect(await resolveShortCircuit(onlyHoles, 2, true)).toBe(false);
-    expect(await resolveShortCircuit([], 1, false)).toBe(true);
+    expect(
+      (await resolveShortCircuit(onlyHoles, 2, UNION_REDUCER)).allowed,
+    ).toBe(false);
+    expect(
+      (await resolveShortCircuit([], 1, INTERSECTION_REDUCER)).allowed,
+    ).toBe(true);
   });
 
   test("synchronously-throwing handler counts as a rejected branch", async () => {
     // Before hardening, a sync throw launched from the refill path
     // leaked its slot (permanent active over-count -> stall) and
     // escaped as an unhandled rejection.
-    const thrower = (): Promise<boolean> => {
-      throw new SyncBoom("sync boom");
-    };
-
     const laterTrueWins = await resolveShortCircuit(
-      [async () => false, thrower, async () => true],
+      [deny, thrower, grant],
       1,
-      true,
+      UNION_REDUCER,
     );
-    expect(laterTrueWins).toBe(true);
+    expect(laterTrueWins.allowed).toBe(true);
 
     await expect(
-      resolveShortCircuit([async () => false, thrower], 1, true),
+      resolveShortCircuit([deny, thrower], 1, UNION_REDUCER),
     ).rejects.toBeInstanceOf(SyncBoom);
 
     // Intersection dual: a sync throw with no definitive false
     // rejects; a definitive false still beats it.
     await expect(
-      resolveShortCircuit([async () => true, thrower], 1, false),
+      resolveShortCircuit([grant, thrower], 1, INTERSECTION_REDUCER),
     ).rejects.toBeInstanceOf(SyncBoom);
     const falseBeatsThrow = await resolveShortCircuit(
-      [thrower, async () => false],
+      [thrower, deny],
       1,
-      false,
+      INTERSECTION_REDUCER,
     );
-    expect(falseBeatsThrow).toBe(false);
+    expect(falseBeatsThrow.allowed).toBe(false);
+  });
+
+  test("cycle flag folds per the reducer, not as a plain false", async () => {
+    // The two reducers differ exactly here, so pin it directly on
+    // the combinator rather than only through check().
+    const cycle = async (): Promise<CheckResult> => ({
+      allowed: false,
+      cycleDetected: true,
+    });
+
+    // Union: a cycle among all-false branches makes the false
+    // indeterminate; a grant anywhere clears it again.
+    const unionCycled = await resolveShortCircuit(
+      [deny, cycle],
+      1,
+      UNION_REDUCER,
+    );
+    expect(unionCycled.allowed).toBe(false);
+    expect(unionCycled.cycleDetected).toBe(true);
+
+    const unionGranted = await resolveShortCircuit(
+      [cycle, grant],
+      1,
+      UNION_REDUCER,
+    );
+    expect(unionGranted.allowed).toBe(true);
+    expect(unionGranted.cycleDetected).toBe(false);
+
+    // Intersection: a cycle decides the whole operand set, and
+    // carries its flag out.
+    const intersected = await resolveShortCircuit(
+      [grant, cycle, grant],
+      1,
+      INTERSECTION_REDUCER,
+    );
+    expect(intersected.allowed).toBe(false);
+    expect(intersected.cycleDetected).toBe(true);
+
+    // An error still outranks a cycle-flagged false in a union.
+    await expect(
+      resolveShortCircuit([cycle, thrower], 1, UNION_REDUCER),
+    ).rejects.toBeInstanceOf(SyncBoom);
   });
 });

--- a/packages/core/tests/check-concurrency.test.ts
+++ b/packages/core/tests/check-concurrency.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { check } from "../src/check.ts";
 import {
   ConditionNotFoundError,
-  DepthExceededError,
   RelationConfigNotFoundError,
 } from "../src/errors.ts";
 import type { RelationConfig, Tuple } from "../src/types.ts";
+import {
+  ConfigErrorStore,
+  StoreReadFailure,
+} from "./helpers/erroring-store.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
 function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
@@ -383,25 +386,20 @@ describe("single-wave node reads", () => {
     // Two erroring branches, no grant: the faster error wins, as
     // in OpenFGA's union (error identity is completion-ordered).
     // Here the direct branch's condition lookup is slowed, so the
-    // sibling cycle error surfaces deterministically.
-    class SlowConditionStore extends MockTupleStore {
+    // sibling's config-read failure surfaces deterministically.
+    class SlowConditionStore extends ConfigErrorStore {
       override async findConditionDefinition(name: string) {
         await delay(20);
         return super.findConditionDefinition(name);
       }
     }
-    const store = new SlowConditionStore();
+    const store = new SlowConditionStore(["broken"]);
     store.relationConfigs.push(
       makeConfig({
         objectType: "doc",
         relation: "viewer",
         directlyAssignableTypes: ["user"],
-        impliedBy: ["looper"],
-      }),
-      makeConfig({
-        objectType: "doc",
-        relation: "looper",
-        impliedBy: ["viewer"],
+        impliedBy: ["broken"],
       }),
     );
     store.tuples.push(
@@ -423,7 +421,7 @@ describe("single-wave node reads", () => {
         subjectType: "user",
         subjectId: "alice",
       }),
-    ).rejects.toBeInstanceOf(DepthExceededError);
+    ).rejects.toBeInstanceOf(StoreReadFailure);
   });
 
   test("tuples sampled before a mid-request config swap deny", async () => {

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -972,27 +972,143 @@ describe("check algorithm", () => {
   });
 
   describe("Cycle detection", () => {
-    test("throws DepthExceededError on cyclic implied_by", async () => {
+    const aRequest = {
+      objectType: "doc",
+      objectId: "1",
+      relation: "a",
+      subjectType: "user",
+      subjectId: "alice",
+    };
+
+    test("cyclic implied_by denies instead of erroring", async () => {
+      // OpenFGA returns Allowed:false with an internal
+      // CycleDetected flag; only depth exhaustion is an error.
       store.relationConfigs.push(
         makeConfig({ objectType: "doc", relation: "a", impliedBy: ["b"] }),
         makeConfig({ objectType: "doc", relation: "b", impliedBy: ["a"] }),
       );
 
-      await expect(
-        check(store, {
+      expect(await check(store, aRequest)).toBe(false);
+    });
+
+    test("a granting sibling beats a cyclic union branch", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "a",
+          impliedBy: ["b", "admin"],
+        }),
+        makeConfig({ objectType: "doc", relation: "b", impliedBy: ["a"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "admin",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "admin",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(await check(store, aRequest)).toBe(true);
+    });
+
+    test("a cycle in an intersection operand denies", async () => {
+      // The operand could not be resolved, so it cannot be shown
+      // to hold: fail closed, even though the other operand grants.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "a",
+          intersection: [
+            { type: "computedUserset", relation: "member" },
+            { type: "computedUserset", relation: "b" },
+          ],
+        }),
+        makeConfig({ objectType: "doc", relation: "b", impliedBy: ["a"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "member",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(await check(store, aRequest)).toBe(false);
+    });
+
+    test("a cycle on the base side of an exclusion denies", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "a",
+          impliedBy: ["b"],
+          excludedBy: "banned",
+        }),
+        makeConfig({ objectType: "doc", relation: "b", impliedBy: ["a"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+
+      expect(await check(store, aRequest)).toBe(false);
+    });
+
+    test("a cycle on the subtract side of an exclusion denies", async () => {
+      // The case that makes indeterminacy worth tracking. The base
+      // grants outright; treating the cycled subtract branch as a
+      // plain `false` would read as "not excluded" and grant —
+      // fail-open. OpenFGA short-circuits to deny instead.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "a",
+          directlyAssignableTypes: ["user"],
+          excludedBy: "banned",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned",
+          impliedBy: ["banned_loop"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned_loop",
+          impliedBy: ["banned"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
           objectType: "doc",
           objectId: "1",
           relation: "a",
           subjectType: "user",
           subjectId: "alice",
         }),
-      ).rejects.toBeInstanceOf(DepthExceededError);
+      );
+
+      expect(await check(store, aRequest)).toBe(false);
     });
 
     test("long rewrite cycle terminates without the depth guard", async () => {
       // 40 rewrite hops on doc:1 closing back on lvl0 — longer than
       // the default budget of 25, but rewrites cost no depth, so
-      // only the resolution path can stop it. It must reject, not
+      // only the resolution path can stop it. It must settle, not
       // hang. This is the safety argument for charging no depth on
       // rewrites: one object has a finite set of relations, so the
       // path Set always closes the loop.
@@ -1007,14 +1123,123 @@ describe("check algorithm", () => {
         );
       }
 
-      await expect(
-        check(store, {
+      expect(
+        await check(store, {
           objectType: "doc",
           objectId: "1",
           relation: "lvl0",
           subjectType: "user",
           subjectId: "alice",
         }),
+      ).toBe(false);
+    });
+
+    test("recursive-shape loop is indeterminate (known divergence)", async () => {
+      // group:a#member -> group:b#member -> group:a#member, on a
+      // single self-referencing relation. OpenFGA routes this
+      // shape to a recursive resolver that walks the reachable
+      // set iteratively and returns a definitive `false`, so on
+      // the subtract side of a but-not it GRANTS. tsfga has one
+      // resolver, sees a path cycle, and denies.
+      //
+      // Pinned deliberately: it is the only position where the
+      // two engines disagree about cycles, it fails closed, and
+      // it is documented in the package README. Verified against
+      // OpenFGA v1.18.2 — see tests/conformance/cycles.test.ts,
+      // which covers every position where they do agree.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "a",
+          directlyAssignableTypes: ["user"],
+          excludedBy: "cyclic",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "cyclic",
+          directlyAssignableTypes: ["group"],
+          allowsUsersetSubjects: true,
+        }),
+        makeConfig({
+          objectType: "group",
+          relation: "member",
+          directlyAssignableTypes: ["user", "group"],
+          allowsUsersetSubjects: true,
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "a",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "cyclic",
+          subjectType: "group",
+          subjectId: "a",
+          subjectRelation: "member",
+        }),
+        makeTuple({
+          objectType: "group",
+          objectId: "a",
+          relation: "member",
+          subjectType: "group",
+          subjectId: "b",
+          subjectRelation: "member",
+        }),
+        makeTuple({
+          objectType: "group",
+          objectId: "b",
+          relation: "member",
+          subjectType: "group",
+          subjectId: "a",
+          subjectRelation: "member",
+        }),
+      );
+
+      // OpenFGA answers true here; tsfga denies.
+      expect(await check(store, aRequest)).toBe(false);
+    });
+
+    test("depth exhaustion still errors, unlike a cycle", async () => {
+      // The two used to be one code path; they are now distinct and
+      // must stay so — converting exhaustion to `false` would fail
+      // open inside an exclusion.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "group",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: true,
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "group",
+          objectId: "0",
+          relation: "member",
+          subjectType: "group",
+          subjectId: "1",
+          subjectRelation: "member",
+        }),
+      );
+
+      await expect(
+        check(
+          store,
+          {
+            objectType: "group",
+            objectId: "0",
+            relation: "member",
+            subjectType: "user",
+            subjectId: "alice",
+          },
+          { maxDepth: 1 },
+        ),
       ).rejects.toBeInstanceOf(DepthExceededError);
     });
   });

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -8,6 +8,10 @@ import {
 } from "../src/errors.ts";
 import { createTsfga } from "../src/index.ts";
 import type { RelationConfig, Tuple } from "../src/types.ts";
+import {
+  ConfigErrorStore,
+  StoreReadFailure,
+} from "./helpers/erroring-store.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
 function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
@@ -1013,20 +1017,21 @@ describe("check algorithm", () => {
         }),
       ).rejects.toBeInstanceOf(DepthExceededError);
     });
+  });
 
-    test("true branch wins over a cyclic sibling branch", async () => {
-      // member is implied by both a cyclic relation and admin;
-      // the cyclic branch throws but the admin branch grants.
-      store.relationConfigs.push(
+  describe("Union error semantics", () => {
+    /**
+     * member is implied by a branch whose config read fails and by
+     * admin. The error source is deliberately *not* a cycle: the
+     * contract here is about any failing branch.
+     */
+    function unionStore(): ConfigErrorStore {
+      const erring = new ConfigErrorStore(["broken"]);
+      erring.relationConfigs.push(
         makeConfig({
           objectType: "doc",
           relation: "member",
-          impliedBy: ["looper", "admin"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "looper",
-          impliedBy: ["member"],
+          impliedBy: ["broken", "admin"],
         }),
         makeConfig({
           objectType: "doc",
@@ -1034,7 +1039,20 @@ describe("check algorithm", () => {
           directlyAssignableTypes: ["user"],
         }),
       );
-      store.tuples.push(
+      return erring;
+    }
+
+    const memberRequest = {
+      objectType: "doc",
+      objectId: "1",
+      relation: "member",
+      subjectType: "user",
+      subjectId: "alice",
+    };
+
+    test("true branch wins over an erroring sibling branch", async () => {
+      const erring = unionStore();
+      erring.tuples.push(
         makeTuple({
           objectType: "doc",
           objectId: "1",
@@ -1044,73 +1062,33 @@ describe("check algorithm", () => {
         }),
       );
 
-      expect(
-        await check(store, {
-          objectType: "doc",
-          objectId: "1",
-          relation: "member",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).toBe(true);
+      expect(await check(erring, memberRequest)).toBe(true);
     });
 
     test("propagates error when no sibling branch grants", async () => {
-      store.relationConfigs.push(
-        makeConfig({
-          objectType: "doc",
-          relation: "member",
-          impliedBy: ["looper", "admin"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "looper",
-          impliedBy: ["member"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "admin",
-          directlyAssignableTypes: ["user"],
-        }),
-      );
-      // alice has no admin tuple: the cyclic branch's error must
+      // alice has no admin tuple: the failing branch's error must
       // surface instead of resolving false.
-      await expect(
-        check(store, {
-          objectType: "doc",
-          objectId: "1",
-          relation: "member",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).rejects.toBeInstanceOf(DepthExceededError);
+      await expect(check(unionStore(), memberRequest)).rejects.toBeInstanceOf(
+        StoreReadFailure,
+      );
     });
   });
 
-  describe("Exclusion fails closed on depth exhaustion", () => {
-    test("cyclic exclusion branch throws instead of granting", async () => {
+  describe("Exclusion fails closed on a failed branch", () => {
+    test("errored exclusion branch throws instead of granting", async () => {
       // carl has a direct editor tuple, but the excludedBy relation
-      // cannot be resolved (cyclic). Pre-0.3.0 this failed open:
-      // the truncated exclusion read as "not excluded" and granted.
-      store.relationConfigs.push(
+      // cannot be resolved. Pre-0.3.0 this failed open: the
+      // truncated exclusion read as "not excluded" and granted.
+      const erring = new ConfigErrorStore(["banned"]);
+      erring.relationConfigs.push(
         makeConfig({
           objectType: "doc",
           relation: "editor",
           directlyAssignableTypes: ["user"],
           excludedBy: "banned",
         }),
-        makeConfig({
-          objectType: "doc",
-          relation: "banned",
-          impliedBy: ["banned_loop"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "banned_loop",
-          impliedBy: ["banned"],
-        }),
       );
-      store.tuples.push(
+      erring.tuples.push(
         makeTuple({
           objectType: "doc",
           objectId: "1",
@@ -1121,14 +1099,14 @@ describe("check algorithm", () => {
       );
 
       await expect(
-        check(store, {
+        check(erring, {
           objectType: "doc",
           objectId: "1",
           relation: "editor",
           subjectType: "user",
           subjectId: "carl",
         }),
-      ).rejects.toBeInstanceOf(DepthExceededError);
+      ).rejects.toBeInstanceOf(StoreReadFailure);
     });
 
     test("deep exclusion branch throws instead of granting", async () => {
@@ -1203,22 +1181,18 @@ describe("check algorithm", () => {
     });
 
     test("base false denies even when exclusion branch errors", async () => {
-      store.relationConfigs.push(
+      const erring = new ConfigErrorStore(["banned"]);
+      erring.relationConfigs.push(
         makeConfig({
           objectType: "doc",
           relation: "editor",
           directlyAssignableTypes: ["user"],
           excludedBy: "banned",
         }),
-        makeConfig({
-          objectType: "doc",
-          relation: "banned",
-          impliedBy: ["banned"],
-        }),
       );
       // No editor tuple: definite deny regardless of exclusion.
       expect(
-        await check(store, {
+        await check(erring, {
           objectType: "doc",
           objectId: "1",
           relation: "editor",
@@ -1230,65 +1204,72 @@ describe("check algorithm", () => {
   });
 
   describe("Definitive deny beats sibling error (OpenFGA parity)", () => {
+    /** can_view = member AND broken, where broken's config read fails. */
+    function intersectionStore(): ConfigErrorStore {
+      const erring = new ConfigErrorStore(["broken"]);
+      erring.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "can_view",
+          intersection: [
+            { type: "computedUserset", relation: "member" },
+            { type: "computedUserset", relation: "broken" },
+          ],
+          allowsUsersetSubjects: false,
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      return erring;
+    }
+
+    /** viewer = broken BUT NOT banned, where broken's read fails. */
+    function exclusionStore(): ConfigErrorStore {
+      const erring = new ConfigErrorStore(["broken"]);
+      erring.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          impliedBy: ["broken"],
+          excludedBy: "banned",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "banned",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      return erring;
+    }
+
+    const canViewRequest = {
+      objectType: "doc",
+      objectId: "1",
+      relation: "can_view",
+      subjectType: "user",
+      subjectId: "alice",
+    };
+    const viewerRequest = {
+      objectType: "doc",
+      objectId: "1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+    };
+
     test("intersection: false operand overrides erroring operand", async () => {
       // OpenFGA's intersection swallows errors when another
       // operand is definitively false.
-      store.relationConfigs.push(
-        makeConfig({
-          objectType: "doc",
-          relation: "can_view",
-          intersection: [
-            { type: "computedUserset", relation: "member" },
-            { type: "computedUserset", relation: "erring" },
-          ],
-          allowsUsersetSubjects: false,
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "member",
-          directlyAssignableTypes: ["user"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "erring",
-          impliedBy: ["erring"],
-        }),
-      );
-      // alice is not a member: false wins over the cycle error.
-      expect(
-        await check(store, {
-          objectType: "doc",
-          objectId: "1",
-          relation: "can_view",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).toBe(false);
+      // alice is not a member: false wins over the read failure.
+      expect(await check(intersectionStore(), canViewRequest)).toBe(false);
     });
 
     test("intersection: true operand plus error still throws", async () => {
-      store.relationConfigs.push(
-        makeConfig({
-          objectType: "doc",
-          relation: "can_view",
-          intersection: [
-            { type: "computedUserset", relation: "member" },
-            { type: "computedUserset", relation: "erring" },
-          ],
-          allowsUsersetSubjects: false,
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "member",
-          directlyAssignableTypes: ["user"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "erring",
-          impliedBy: ["erring"],
-        }),
-      );
-      store.tuples.push(
+      const erring = intersectionStore();
+      erring.tuples.push(
         makeTuple({
           objectType: "doc",
           objectId: "1",
@@ -1298,39 +1279,16 @@ describe("check algorithm", () => {
         }),
       );
       // No operand is definitively false: fail closed on the error.
-      await expect(
-        check(store, {
-          objectType: "doc",
-          objectId: "1",
-          relation: "can_view",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).rejects.toBeInstanceOf(DepthExceededError);
+      await expect(check(erring, canViewRequest)).rejects.toBeInstanceOf(
+        StoreReadFailure,
+      );
     });
 
     test("exclusion: granted exclusion branch overrides base error", async () => {
       // OpenFGA short-circuits to deny when the subtracted branch
       // grants, even if the base errored.
-      store.relationConfigs.push(
-        makeConfig({
-          objectType: "doc",
-          relation: "viewer",
-          impliedBy: ["looper"],
-          excludedBy: "banned",
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "looper",
-          impliedBy: ["viewer"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "banned",
-          directlyAssignableTypes: ["user"],
-        }),
-      );
-      store.tuples.push(
+      const erring = exclusionStore();
+      erring.tuples.push(
         makeTuple({
           objectType: "doc",
           objectId: "1",
@@ -1339,47 +1297,15 @@ describe("check algorithm", () => {
           subjectId: "alice",
         }),
       );
-      // The base cycles (error) but alice is banned: deny.
-      expect(
-        await check(store, {
-          objectType: "doc",
-          objectId: "1",
-          relation: "viewer",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).toBe(false);
+      // The base errors but alice is banned: deny.
+      expect(await check(erring, viewerRequest)).toBe(false);
     });
 
     test("exclusion: base error with false exclusion still throws", async () => {
-      store.relationConfigs.push(
-        makeConfig({
-          objectType: "doc",
-          relation: "viewer",
-          impliedBy: ["looper"],
-          excludedBy: "banned",
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "looper",
-          impliedBy: ["viewer"],
-        }),
-        makeConfig({
-          objectType: "doc",
-          relation: "banned",
-          directlyAssignableTypes: ["user"],
-        }),
-      );
       // alice is not banned: the base error must fail closed.
       await expect(
-        check(store, {
-          objectType: "doc",
-          objectId: "1",
-          relation: "viewer",
-          subjectType: "user",
-          subjectId: "alice",
-        }),
-      ).rejects.toBeInstanceOf(DepthExceededError);
+        check(exclusionStore(), viewerRequest),
+      ).rejects.toBeInstanceOf(StoreReadFailure);
     });
   });
 

--- a/packages/core/tests/helpers/erroring-store.ts
+++ b/packages/core/tests/helpers/erroring-store.ts
@@ -1,0 +1,89 @@
+import type { RelationConfig, Tuple } from "../../src/types.ts";
+import { MockTupleStore } from "./mock-store.ts";
+
+/**
+ * Error raised by the stores below. A plain `Error` subclass, not
+ * a `TsfgaError`: these stand in for a backend failure (dropped
+ * connection, timeout), which the check algorithm propagates
+ * without interpreting.
+ */
+export class StoreReadFailure extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StoreReadFailure";
+  }
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A non-cycle error source for the error-semantics suites.
+ *
+ * Those suites assert contracts about *any* failing branch — a
+ * sibling `true` beats an error, exclusion and intersection fail
+ * closed, a definitive deny short-circuits past an error. They
+ * used to raise those errors by wiring a cyclic relation, which
+ * was convenient but coupled them to what a cycle means. It does
+ * not mean "error" in OpenFGA: a cycle resolves to `false` with
+ * an internal flag, and only depth exhaustion is an error. A
+ * store-level read failure keeps every contract under test and
+ * drops the coupling, so cycle semantics can be corrected without
+ * rewriting suites that were never about cycles.
+ *
+ * Tests that are genuinely about cycles or about depth exhaustion
+ * still use those directly.
+ */
+export class ConfigErrorStore extends MockTupleStore {
+  /**
+   * @param erringRelations relations whose config read rejects
+   * @param delayMs how long to stall before rejecting, for tests
+   *   that need the failure to land after a sibling settles
+   */
+  constructor(
+    private readonly erringRelations: readonly string[],
+    private readonly delayMs = 0,
+  ) {
+    super();
+  }
+
+  override async findRelationConfig(
+    objectType: string,
+    relation: string,
+  ): Promise<RelationConfig | null> {
+    if (this.erringRelations.includes(relation)) {
+      if (this.delayMs > 0) {
+        await delay(this.delayMs);
+      }
+      throw new StoreReadFailure(
+        `config read failed for ${objectType}.${relation}`,
+      );
+    }
+    return super.findRelationConfig(objectType, relation);
+  }
+}
+
+/**
+ * Rejects the userset scan for the named relations instead of the
+ * config read, so a branch can fail *after* its config resolved —
+ * the other half of the node's single read wave.
+ */
+export class UsersetErrorStore extends MockTupleStore {
+  constructor(private readonly erringRelations: readonly string[]) {
+    super();
+  }
+
+  override async findUsersetTuples(
+    objectType: string,
+    objectId: string,
+    relation: string,
+  ): Promise<Tuple[]> {
+    if (this.erringRelations.includes(relation)) {
+      throw new StoreReadFailure(
+        `userset scan failed for ${objectType}.${relation}`,
+      );
+    }
+    return super.findUsersetTuples(objectType, objectId, relation);
+  }
+}

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -62,6 +62,9 @@ bun run turbo:test:conformance
 - `deep-rewrite` — a rewrite ladder deeper than the
   default depth limit of 25; pins that rewrites of the
   same object cost no resolution depth
+- `cycles` — loops in the tuple graph; pins that a cycle
+  denies rather than erroring, and that it denies on the
+  subtract side of a `but not`
 - `condition-error-siblings` — how a condition error on
   one branch interacts with its siblings
 

--- a/tests/conformance/cycles.test.ts
+++ b/tests/conformance/cycles.test.ts
@@ -1,0 +1,392 @@
+import { afterAll, beforeAll, describe, test } from "bun:test";
+import { createTsfga, type TsfgaClient } from "@tsfga/core";
+import type { DB } from "@tsfga/kysely";
+import { KyselyTupleStore } from "@tsfga/kysely";
+import type { Kysely } from "kysely";
+import { expectConformance } from "./helpers/conformance.ts";
+import {
+  beginTransaction,
+  destroyDb,
+  getDb,
+  rollbackTransaction,
+} from "./helpers/db.ts";
+import {
+  fgaCreateStore,
+  fgaWriteModel,
+  fgaWriteTuples,
+} from "./helpers/openfga.ts";
+
+// Cycles in the resolution path.
+//
+// OpenFGA does not treat a cycle as an error. `ResolveCheck`
+// errors only when the depth budget is exhausted; revisiting a
+// node returns `Allowed:false` with `CycleDetected:true` and a nil
+// error. tsfga used to throw DepthExceededError for both, so every
+// case below except the plain union grant failed before this
+// fixture existed.
+//
+// The flag is not merely a `false`, which is why it has to be
+// carried rather than collapsed into one:
+//
+//   union       a cycle among losing branches keeps the `false`;
+//               a granting sibling wins outright
+//   intersect   a cycled operand short-circuits to deny — it could
+//               not be shown to hold
+//   base of     behaves like `false`
+//   `but not`
+//   subtract    behaves like `true` — the exclusion could not be
+//   of          ruled out, so access is DENIED. Implementing "a
+//   `but not`   cycle is just false" grants here: a fail-open.
+//
+// Two things had to be discovered against the running container
+// rather than read off the Go source, and both shape this fixture.
+//
+// First, the cycle is built from tuples, not from the model.
+// OpenFGA's typesystem rejects a relation whose rewrite is
+// self-referencing through computed usersets — writing
+// `define x: y` / `define y: x` to a store fails with "an
+// authorization model cannot contain a cycle". The Go unit test
+// that resolves such a model builds the typesystem directly and
+// never runs relation validation.
+//
+// Second, the loop alternates two relations (member -> owner ->
+// member). A loop on one self-referencing relation
+// (`member: [user, group#member]`), or a looping TTU parent
+// chain, is served by OpenFGA's recursive-relation resolvers,
+// which walk the reachable set iteratively and return a
+// definitive `false` with no cycle flag. Only shapes that fall
+// through to the ordinary resolver set it. `recursive_group`
+// below keeps the recursive shape in the suite for the cases
+// where the two engines agree either way — see the divergence
+// note in packages/core/README.md for the one case they do not.
+//
+// Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L419
+// Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L358
+// Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/pkg/typesystem/typesystem.go#L1448
+
+const uuidMap = new Map<string, string>([
+  ["anne", "00000000-0000-4000-c700-000000000001"],
+  ["carl", "00000000-0000-4000-c700-000000000002"],
+  ["dave", "00000000-0000-4000-c700-000000000003"],
+  ["1", "00000000-0000-4000-c700-000000000004"],
+  ["loopa", "00000000-0000-4000-c700-000000000005"],
+  ["loopb", "00000000-0000-4000-c700-000000000006"],
+  ["ra", "00000000-0000-4000-c700-000000000007"],
+  ["rb", "00000000-0000-4000-c700-000000000008"],
+]);
+
+function uuid(name: string): string {
+  const id = uuidMap.get(name);
+  if (!id) throw new Error(`No UUID for ${name}`);
+  return id;
+}
+
+describe("Cycle Conformance", () => {
+  let db: Kysely<DB>;
+  let storeId: string;
+  let authorizationModelId: string;
+  let tsfgaClient: TsfgaClient;
+
+  async function expectCycle(
+    relation: string,
+    subject: string,
+    expected: boolean,
+  ): Promise<void> {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation,
+        subjectType: "user",
+        subjectId: uuid(subject),
+      },
+      expected,
+    );
+  }
+
+  beforeAll(async () => {
+    db = getDb();
+    await beginTransaction(db);
+
+    const store = new KyselyTupleStore(db);
+    tsfgaClient = createTsfga(store);
+
+    // === Relation configs ===
+    for (const relation of ["member", "owner"]) {
+      await tsfgaClient.writeRelationConfig({
+        objectType: "group",
+        relation,
+        directlyAssignableTypes: ["user", "group"],
+        impliedBy: null,
+        computedUserset: null,
+        tupleToUserset: null,
+        excludedBy: null,
+        intersection: null,
+        allowsUsersetSubjects: true,
+      });
+    }
+    await tsfgaClient.writeRelationConfig({
+      objectType: "recursive_group",
+      relation: "member",
+      directlyAssignableTypes: ["user", "recursive_group"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: true,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "cyclic",
+      directlyAssignableTypes: ["group"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: true,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "recursive_cyclic",
+      directlyAssignableTypes: ["recursive_group"],
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: true,
+    });
+    for (const relation of ["granted", "base", "blocked"]) {
+      await tsfgaClient.writeRelationConfig({
+        objectType: "document",
+        relation,
+        directlyAssignableTypes: ["user"],
+        impliedBy: null,
+        computedUserset: null,
+        tupleToUserset: null,
+        excludedBy: null,
+        intersection: null,
+        allowsUsersetSubjects: false,
+      });
+    }
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "union_with_cycle",
+      directlyAssignableTypes: null,
+      impliedBy: ["cyclic", "granted"],
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "subtract_cycle",
+      directlyAssignableTypes: null,
+      impliedBy: ["base"],
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: "cyclic",
+      intersection: null,
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "cyclic_base",
+      directlyAssignableTypes: null,
+      impliedBy: ["cyclic"],
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: "blocked",
+      intersection: null,
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "intersect_cycle",
+      directlyAssignableTypes: null,
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: [
+        { type: "computedUserset", relation: "granted" },
+        { type: "computedUserset", relation: "cyclic" },
+      ],
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      objectType: "document",
+      relation: "intersect_recursive",
+      directlyAssignableTypes: null,
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: [
+        { type: "computedUserset", relation: "granted" },
+        { type: "computedUserset", relation: "recursive_cyclic" },
+      ],
+      allowsUsersetSubjects: false,
+    });
+
+    // === Tuples: the loops ===
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "cyclic",
+      subjectType: "group",
+      subjectId: uuid("loopa"),
+      subjectRelation: "member",
+    });
+    // loopa#member -> loopb#owner -> loopa#member
+    await tsfgaClient.addTuple({
+      objectType: "group",
+      objectId: uuid("loopa"),
+      relation: "member",
+      subjectType: "group",
+      subjectId: uuid("loopb"),
+      subjectRelation: "owner",
+    });
+    await tsfgaClient.addTuple({
+      objectType: "group",
+      objectId: uuid("loopb"),
+      relation: "owner",
+      subjectType: "group",
+      subjectId: uuid("loopa"),
+      subjectRelation: "member",
+    });
+
+    // The recursive-shape loop.
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "recursive_cyclic",
+      subjectType: "recursive_group",
+      subjectId: uuid("ra"),
+      subjectRelation: "member",
+    });
+    for (const [object, subject] of [
+      ["ra", "rb"],
+      ["rb", "ra"],
+    ] as const) {
+      await tsfgaClient.addTuple({
+        objectType: "recursive_group",
+        objectId: uuid(object),
+        relation: "member",
+        subjectType: "recursive_group",
+        subjectId: uuid(subject),
+        subjectRelation: "member",
+      });
+    }
+
+    // === Tuples: the users ===
+    for (const [subject, relations] of [
+      ["anne", ["granted", "base"]],
+      ["carl", ["base"]],
+    ] as const) {
+      for (const relation of relations) {
+        await tsfgaClient.addTuple({
+          objectType: "document",
+          objectId: uuid("1"),
+          relation,
+          subjectType: "user",
+          subjectId: uuid(subject),
+        });
+      }
+    }
+    // carl is a real member of a looping group.
+    await tsfgaClient.addTuple({
+      objectType: "group",
+      objectId: uuid("loopa"),
+      relation: "member",
+      subjectType: "user",
+      subjectId: uuid("carl"),
+    });
+
+    // Setup OpenFGA
+    storeId = await fgaCreateStore("cycles-conformance");
+    authorizationModelId = await fgaWriteModel(storeId, "./cycles/model.dsl");
+    await fgaWriteTuples(
+      storeId,
+      "./cycles/tuples.yaml",
+      authorizationModelId,
+      uuidMap,
+    );
+  });
+
+  afterAll(async () => {
+    await rollbackTransaction(db);
+    await destroyDb();
+  });
+
+  test("1: a plain cycle denies rather than erroring", async () => {
+    await expectCycle("cyclic", "anne", false);
+  });
+
+  test("2: a real path through the loop still resolves", async () => {
+    await expectCycle("cyclic", "carl", true);
+  });
+
+  test("3: a granting sibling beats a cyclic union branch", async () => {
+    await expectCycle("union_with_cycle", "anne", true);
+  });
+
+  test("4: a union of a cycle and a miss denies", async () => {
+    await expectCycle("union_with_cycle", "dave", false);
+  });
+
+  test("5: a cycle on the subtract side of but-not denies", async () => {
+    // The fail-open case. anne holds `base`, so the base side
+    // grants; the subtract side cycles. Reading that cycle as a
+    // plain `false` would mean "not excluded" and grant.
+    await expectCycle("subtract_cycle", "anne", false);
+  });
+
+  test("6: a resolved subtract side still excludes normally", async () => {
+    // Control for case 5: carl reaches the loop for real, so the
+    // denial has an ordinary cause. Same answer, different reason.
+    await expectCycle("subtract_cycle", "carl", false);
+  });
+
+  test("7: no base means but-not denies regardless of the cycle", async () => {
+    await expectCycle("subtract_cycle", "dave", false);
+  });
+
+  test("8: a cycle on the base side of but-not denies", async () => {
+    await expectCycle("cyclic_base", "anne", false);
+  });
+
+  test("9: a resolved base side still grants", async () => {
+    await expectCycle("cyclic_base", "carl", true);
+  });
+
+  test("10: a cycled intersection operand denies", async () => {
+    // anne satisfies `granted`; the `cyclic` operand cycles and so
+    // cannot be shown to hold.
+    await expectCycle("intersect_cycle", "anne", false);
+  });
+
+  test("11: intersection with a real cycle path is unaffected", async () => {
+    // carl reaches the loop but lacks `granted`.
+    await expectCycle("intersect_cycle", "carl", false);
+  });
+
+  test("12: a recursive-shape loop also denies", async () => {
+    await expectCycle("recursive_cyclic", "anne", false);
+  });
+
+  test("13: a recursive-shape loop denies an intersection too", async () => {
+    // Agrees whether or not the flag was set: a plain `false`
+    // operand denies an intersection just as a cycled one does.
+    // The subtract side of but-not is the only place the two
+    // differ, and that case is the documented divergence.
+    await expectCycle("intersect_recursive", "anne", false);
+  });
+});

--- a/tests/conformance/cycles/model.dsl
+++ b/tests/conformance/cycles/model.dsl
@@ -1,0 +1,26 @@
+model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define member: [user, group#owner]
+    define owner: [user, group#member]
+
+type recursive_group
+  relations
+    define member: [user, recursive_group#member]
+
+type document
+  relations
+    define cyclic: [group#member]
+    define recursive_cyclic: [recursive_group#member]
+    define granted: [user]
+    define base: [user]
+    define blocked: [user]
+    define union_with_cycle: cyclic or granted
+    define subtract_cycle: base but not cyclic
+    define cyclic_base: cyclic but not blocked
+    define intersect_cycle: granted and cyclic
+    define intersect_recursive: granted and recursive_cyclic

--- a/tests/conformance/cycles/tuples.yaml
+++ b/tests/conformance/cycles/tuples.yaml
@@ -1,0 +1,55 @@
+# The cycle lives in the tuples, not the model: OpenFGA's
+# typesystem rejects a relation whose rewrite is self-referencing
+# through computed usersets ("an authorization model cannot
+# contain a cycle"), so a model-level cycle can never be written
+# to a real store.
+#
+# The loop alternates member/owner on purpose. A loop on a single
+# self-referencing relation (`member: [user, group#member]`) is
+# served by OpenFGA's recursive-relation resolver, which walks the
+# reachable set iteratively and reports a definitive `false` with
+# no cycle flag. Alternating two relations is not a recognized
+# recursive shape, so it falls through to the ordinary resolver
+# and the cycle flag is actually set.
+#
+# document:1#cyclic -> group:loopa#member -> group:loopb#owner
+#                   -> group:loopa#member  (loop)
+- user: group:loopa#member
+  relation: cyclic
+  object: document:1
+- user: group:loopb#owner
+  relation: member
+  object: group:loopa
+- user: group:loopa#member
+  relation: owner
+  object: group:loopb
+
+# The recursive-shape loop, kept for the cases where both engines
+# agree regardless of whether the flag is set.
+- user: recursive_group:ra#member
+  relation: recursive_cyclic
+  object: document:1
+- user: recursive_group:rb#member
+  relation: member
+  object: recursive_group:ra
+- user: recursive_group:ra#member
+  relation: member
+  object: recursive_group:rb
+
+# anne sits outside every loop, so resolving `cyclic` for her
+# walks the whole loop and comes back indeterminate.
+- user: user:anne
+  relation: granted
+  object: document:1
+- user: user:anne
+  relation: base
+  object: document:1
+
+# carl is a real member of a looping group, so `cyclic` resolves
+# true for him despite the loop.
+- user: user:carl
+  relation: member
+  object: group:loopa
+- user: user:carl
+  relation: base
+  object: document:1


### PR DESCRIPTION
- **Re-base error-semantics tests off cycles**
  Three core suites used a cyclic relation as a convenient way to
  make a branch fail. That was never what they were testing: their
  contracts are that a sibling `true` beats a branch error, that
  exclusion and intersection fail closed, and that a definitive
  deny short-circuits past an error — all of which hold for any
  failing branch, whatever made it fail.
  
  The coupling is about to become a problem. A cycle is not an
  error in OpenFGA: it resolves to `false` carrying an internal
  flag, and only depth exhaustion errors. Correcting that would
  otherwise churn roughly two dozen assertions that have no opinion
  on cycles, and bury the one diff that does.
  
  So the error source moves to a store-level read failure, in a new
  shared helper. `ConfigErrorStore` rejects the config read for
  named relations, optionally after a delay for the tests that need
  a branch to fail *after* a sibling settles;
  `DelayedConfigErrorStore` in the concurrency suite was already
  the same idea, locally. Two suites needed a store that both fails
  one relation and stalls condition lookups, so their existing
  slow-lookup stores now extend it rather than MockTupleStore.
  
  No production code changes, and every assertion is unchanged
  apart from the error class it names.
  
  What is deliberately left on cycles: the two tests in "Cycle
  detection" that are about cycles, and the depth-exhaustion tests,
  which exhaust the budget with userset chains rather than cycles.
  Those two cycle tests are now the only core tests a change to
  cycle semantics has to touch.
  

- **Resolve cycles as false instead of erroring**
  A cycle in the resolution path raised DepthExceededError, the
  same error as running out of depth budget. Upstream errors only
  on exhaustion; revisiting a node returns Allowed:false with
  CycleDetected:true and a nil error. Seven of the thirteen cases
  in the new conformance fixture failed before this change.
  
  The flag is carried as a per-node result object rather than
  collapsed into a bare false, because the set operators read the
  two differently:
  
  - union branch: cycle keeps the false; a granting sibling wins
  - intersection operand: cycle short-circuits to deny
  - `but not` base: behaves like false — denies
  - `but not` subtract: behaves like TRUE — denies
  
  The subtract row is why this cannot be shipped as "a cycle is
  just false": that spelling grants `base:true butnot sub:cycle`,
  a fail-open. The old behavior was wrong in the other direction —
  it threw where upstream denies — so neither the old code nor the
  naive fix agrees with OpenFGA.
  
  Because union and intersection are no longer exact duals, the
  shared combinator takes a reducer instead of a shortCircuitOn
  flag. The flag stays internal, mirroring upstream, where
  CycleDetected lives in ResolveCheckResponseMetadata and never
  reaches the wire CheckResponse.
  
  Two things in this area could only be settled against the running
  container, and both contradict what the Go source suggests on its
  own:
  
  Model-level cycles cannot be written at all. `define x: y` /
  `define y: x` is rejected by the typesystem with "an
  authorization model cannot contain a cycle". The Go unit test
  that resolves such a model constructs the typesystem directly and
  skips relation validation. So the fixture builds its loop from
  tuples.
  
  A loop on a single self-referencing relation, or a looping TTU
  parent chain, does NOT set the flag: those shapes are served by
  recursive-relation resolvers that walk the reachable set
  iteratively and return a definitive false. Only shapes that fall
  through to the ordinary resolver — here, a loop alternating two
  relations — set it. That leaves a real divergence: with a
  recursive relation looping on the subtract side of a but-not,
  OpenFGA grants and tsfga denies. Every other position agrees,
  since a plain false and a cycled false are indistinguishable
  there. It is recorded in the core README, pinned by a core test
  so it cannot drift unnoticed, and it fails closed.
  
  Breaking: callers catching DepthExceededError to detect a cyclic
  model no longer see it. CHANGELOG updated.
  
  Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L419
  Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L358
  Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L202
  Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/pkg/typesystem/typesystem.go#L1448
  