### PR TITLE
Memoize settled node results per request

### DIFF
--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -81,6 +81,64 @@ export const INTERSECTION_REDUCER: Reducer = {
   accumulate: (acc) => acc,
 };
 
+/** A settled node result, plus the depth it was resolved at. */
+interface MemoEntry {
+  result: CheckResult;
+  depth: number;
+}
+
+/**
+ * Request-scoped memo of settled node results, so a node reached
+ * by several routes is resolved once instead of once per route.
+ * The check graph is a DAG; without this it is explored as a tree.
+ *
+ * Nested rather than keyed on a joined string: ids are not
+ * charset-restricted, so `:` and `#` can occur inside one and a
+ * flat key could collide across different nodes
+ * (`caching-store.ts` sets the precedent). Note that the *path*
+ * key a few lines below does join — two guards in the same
+ * function keyed differently is a trap, so: the path key
+ * deliberately omits the subject, because the subject is constant
+ * for a whole request.
+ *
+ * The memo includes the subject anyway. It is redundant today for
+ * the same reason, but nothing in the types enforces it, and a
+ * future code path that varied the subject would make the path
+ * key merely over-eager while making the memo *wrong*.
+ */
+type MemoMap<V> = Map<string, V>;
+type NodeMemo = MemoMap<MemoMap<MemoMap<MemoMap<MemoMap<MemoEntry>>>>>;
+
+function memoGet(memo: NodeMemo, request: CheckRequest): MemoEntry | undefined {
+  return memo
+    .get(request.subjectType)
+    ?.get(request.subjectId)
+    ?.get(request.objectType)
+    ?.get(request.objectId)
+    ?.get(request.relation);
+}
+
+function memoLevel<V>(map: MemoMap<MemoMap<V>>, key: string): MemoMap<V> {
+  let level = map.get(key);
+  if (!level) {
+    level = new Map();
+    map.set(key, level);
+  }
+  return level;
+}
+
+function memoSet(
+  memo: NodeMemo,
+  request: CheckRequest,
+  entry: MemoEntry,
+): void {
+  const bySubjectId = memoLevel(memo, request.subjectType);
+  const byObjectType = memoLevel(bySubjectId, request.subjectId);
+  const byObjectId = memoLevel(byObjectType, request.objectType);
+  const byRelation = memoLevel(byObjectId, request.objectId);
+  byRelation.set(request.relation, entry);
+}
+
 /**
  * Recursive check algorithm with support for:
  * - Direct tuple check + wildcard
@@ -192,6 +250,7 @@ export async function check(
     maxBreadth,
     0,
     new Set(),
+    new Map(),
   );
   // The indeterminacy flag is internal; a cycle at the root is an
   // ordinary deny to the caller, as it is on OpenFGA's wire.
@@ -199,10 +258,11 @@ export async function check(
 }
 
 /**
- * Resolve one node of the check graph. Tracks the current
- * resolution path in `path` (keys of `objectType:objectId#relation`
- * — the subject is constant per request) so a revisit truncates
- * the subtree instead of recursing forever.
+ * Resolve one node of the check graph, with cycle detection and
+ * memoization. Tracks the current resolution path in `path` (keys
+ * of `objectType:objectId#relation` — the subject is constant per
+ * request) so a revisit truncates the subtree instead of recursing
+ * forever.
  */
 async function checkNode(
   store: TupleStore,
@@ -211,6 +271,7 @@ async function checkNode(
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
+  memo: NodeMemo,
 ): Promise<CheckResult> {
   // `depth` counts dispatches already made, so the budget is spent
   // once it reaches maxDepth — OpenFGA errors on
@@ -225,9 +286,77 @@ async function checkNode(
     // operators above interpret for themselves.
     return CYCLE;
   }
+
+  // Consulted *after* the cycle guard: a node already on this path
+  // is a cycle no matter what some other branch concluded about it.
+  //
+  // Reuse is gated on depth. An entry recorded at depth D resolved
+  // without exhausting the budget, so it needed at most
+  // `maxDepth - D` levels; at any depth <= D there is at least that
+  // much headroom left, so the same subtree resolves the same way.
+  // Deeper is not safe: reusing it there could answer where a fresh
+  // resolution would have thrown DepthExceededError. Recording the
+  // greatest depth seen therefore widens the range of reuse.
+  const memoized = memoGet(memo, request);
+  if (memoized && depth <= memoized.depth) {
+    return memoized.result;
+  }
+
   const visited = new Set(path);
   visited.add(key);
 
+  const result = await resolveNode(
+    store,
+    request,
+    maxDepth,
+    maxBreadth,
+    depth,
+    visited,
+    memo,
+  );
+
+  // Only path-independent results are publishable.
+  //
+  // An indeterminate result is exactly the path-dependent case: the
+  // subtree was truncated because it looped back onto *this* path,
+  // and a different route to the same node would not have been. So
+  // the flag, which every operator propagates for the branch it
+  // returned, is the whole test — nothing else has to be inspected.
+  //
+  // What survives is sound by induction. A grant is a proof found,
+  // and a proof does not stop existing on another route. A `false`
+  // with no flag means every branch was refuted with no branch
+  // truncated and none errored — errors reject rather than resolve,
+  // and the two operators that swallow a sibling error do so only
+  // behind a definitive deny (an intersection operand that is
+  // false, an exclusion base that is false), which is itself
+  // path-independent.
+  //
+  // A throw is simply never recorded, which is also how a
+  // depth-exhausted subtree stays out: nothing is written, so the
+  // same node resolves normally if it is reached again shallower.
+  // Nothing in-flight is ever published, so unlike the store cache
+  // there is no promise to evict and no rejection to swallow.
+  if (!result.cycleDetected && (!memoized || depth > memoized.depth)) {
+    memoSet(memo, request, { result, depth });
+  }
+  return result;
+}
+
+/**
+ * The body of one node's resolution: steps 1-5, intersection, and
+ * exclusion. Split out of `checkNode` so the cycle guard, the memo
+ * lookup and the memo write bracket a single call.
+ */
+async function resolveNode(
+  store: TupleStore,
+  request: CheckRequest,
+  maxDepth: number,
+  maxBreadth: number,
+  depth: number,
+  visited: ReadonlySet<string>,
+  memo: NodeMemo,
+): Promise<CheckResult> {
   // Speculatively start the tuple batch so it overlaps the config
   // fetch: one round-trip wave per node instead of two. Some paths
   // never await it (config error, or an intersection without a
@@ -254,6 +383,7 @@ async function checkNode(
           maxBreadth,
           depth,
           visited,
+          memo,
         )
       : checkBase(
           store,
@@ -264,6 +394,7 @@ async function checkNode(
           maxBreadth,
           depth,
           visited,
+          memo,
         );
 
   // Exclusion applies on top of the base result — including on top
@@ -294,6 +425,7 @@ async function checkNode(
         maxBreadth,
         depth,
         visited,
+        memo,
       ),
     ]);
     if (
@@ -382,6 +514,7 @@ async function checkBase(
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
+  memo: NodeMemo,
 ): Promise<CheckResult> {
   const [directTuple, wildcardTuple, usersetTuples] = await reads;
 
@@ -433,6 +566,7 @@ async function checkBase(
         maxBreadth,
         depth + 1,
         path,
+        memo,
       );
     });
   }
@@ -450,6 +584,7 @@ async function checkBase(
           maxBreadth,
           depth,
           path,
+          memo,
         ),
       );
     }
@@ -466,6 +601,7 @@ async function checkBase(
         maxBreadth,
         depth,
         path,
+        memo,
       ),
     );
   }
@@ -506,6 +642,7 @@ async function checkBase(
               maxBreadth,
               depth + 1,
               path,
+              memo,
             ),
           );
         }
@@ -530,6 +667,7 @@ async function checkIntersection(
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
+  memo: NodeMemo,
 ): Promise<CheckResult> {
   const operands = config.intersection;
   // An intersection with no operands would resolve vacuously true,
@@ -557,6 +695,7 @@ async function checkIntersection(
           maxBreadth,
           depth,
           path,
+          memo,
         ),
       );
     } else if (operand.type === "computedUserset") {
@@ -569,6 +708,7 @@ async function checkIntersection(
           maxBreadth,
           depth,
           path,
+          memo,
         ),
       );
     } else {
@@ -596,6 +736,7 @@ async function checkIntersection(
               maxBreadth,
               depth + 1,
               path,
+              memo,
             ),
           );
         }

--- a/packages/core/tests/check-memo.test.ts
+++ b/packages/core/tests/check-memo.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import { DepthExceededError } from "../src/errors.ts";
+import type { RelationConfig, Tuple } from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Every test here runs at `maxBreadth: 1` unless it says otherwise.
+ * The memo publishes settled results only — never in-flight
+ * promises, which would deadlock when two sibling branches each
+ * end up awaiting the other's entry — so a hit requires one branch
+ * to have finished before the other starts. Bounded breadth makes
+ * that ordering deterministic instead of a race.
+ */
+const SEQUENTIAL = { maxBreadth: 1 };
+
+describe("request-scoped node memoization", () => {
+  let store: MockTupleStore;
+
+  beforeEach(() => {
+    store = new MockTupleStore();
+  });
+
+  const viewerRequest = {
+    objectType: "doc",
+    objectId: "1",
+    relation: "top",
+    subjectType: "user",
+    subjectId: "alice",
+  };
+
+  describe("shared nodes resolve once", () => {
+    /** top -> {left, right} -> shared. A diamond on one object. */
+    function seedDiamond() {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["left", "right"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "left",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "right",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "shared",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+    }
+
+    test("a definitive false is served from the memo", async () => {
+      // The induction the memo rests on: `shared` is refuted with
+      // no branch truncated and none errored, so it is false by
+      // whatever route it is reached.
+      seedDiamond();
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "shared")).toBe(
+        1,
+      );
+    });
+
+    test("a definitive true is served from the memo", async () => {
+      // A grant is a proof found, and a proof does not stop
+      // existing on another route. `left` grants, so the union at
+      // `top` short-circuits — reach the second route explicitly.
+      seedDiamond();
+      const cfg = store.relationConfigs.find((c) => c.relation === "top");
+      if (cfg) cfg.impliedBy = ["left", "right", "missing"];
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "shared",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(true);
+      // `left` grants and the union stops, so `shared` is read once
+      // — by `left`, never by `right`.
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "shared")).toBe(
+        1,
+      );
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "right")).toBe(0);
+    });
+
+    test("without a shared node nothing is deduplicated", async () => {
+      // Control: the counts above should come from the memo, not
+      // from the graph happening to be small.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["left", "right"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "left",
+          impliedBy: ["l2"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "right",
+          impliedBy: ["r2"],
+        }),
+      );
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "l2")).toBe(1);
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "r2")).toBe(1);
+    });
+  });
+
+  describe("indeterminate results are never published", () => {
+    test("a cycle-truncated node is re-resolved on another route", async () => {
+      // top -> p -> x -> p (cycle), then top -> x directly.
+      // x's first result is `false` only because the path already
+      // held p. Publishing it would poison the second route, which
+      // has a different path. So x must be read twice.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["p", "x"],
+        }),
+        makeConfig({ objectType: "doc", relation: "p", impliedBy: ["x"] }),
+        makeConfig({ objectType: "doc", relation: "x", impliedBy: ["p"] }),
+      );
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "x")).toBe(2);
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "p")).toBe(2);
+    });
+
+    test("a cross-branch cycle terminates instead of deadlocking", async () => {
+      // The shape that rules out coalescing in-flight promises:
+      // at breadth >= 2 both branches are launched before either
+      // settles, and each would end up awaiting the other's entry.
+      // With settled results only there is nothing to await.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["a", "b"],
+        }),
+        makeConfig({ objectType: "doc", relation: "a", impliedBy: ["b"] }),
+        makeConfig({ objectType: "doc", relation: "b", impliedBy: ["a"] }),
+      );
+
+      expect(await check(store, viewerRequest, { maxBreadth: 2 })).toBe(false);
+    });
+
+    test("a granting sibling still wins with the memo in place", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["a", "granted"],
+        }),
+        makeConfig({ objectType: "doc", relation: "a", impliedBy: ["top"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "granted",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "granted",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(true);
+    });
+  });
+
+  describe("reuse is gated on depth", () => {
+    /**
+     * Two routes from doc:1#top to group:g#member at different
+     * depths, since only userset expansion costs depth:
+     *
+     *   short: doc:1#top -> g            (g at depth 1)
+     *   long:  doc:1#top -> a -> b -> g  (g at depth 3)
+     *
+     * g expands once more, to `leaf`, so resolving g costs one
+     * further level. `order` decides which route the union walks
+     * first.
+     */
+    function seedTwoDepths(order: "shortFirst" | "longFirst") {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          directlyAssignableTypes: ["group"],
+          allowsUsersetSubjects: true,
+        }),
+        makeConfig({
+          objectType: "group",
+          relation: "member",
+          directlyAssignableTypes: ["user", "group"],
+          allowsUsersetSubjects: true,
+        }),
+      );
+      const link = (
+        objectType: string,
+        objectId: string,
+        relation: string,
+        subjectId: string,
+      ) =>
+        makeTuple({
+          objectType,
+          objectId,
+          relation,
+          subjectType: "group",
+          subjectId,
+          subjectRelation: "member",
+        });
+
+      const short = link("doc", "1", "top", "g");
+      const long = link("doc", "1", "top", "a");
+      store.tuples.push(
+        ...(order === "shortFirst" ? [short, long] : [long, short]),
+        link("group", "a", "member", "b"),
+        link("group", "b", "member", "g"),
+        link("group", "g", "member", "leaf"),
+      );
+    }
+
+    test("an entry recorded deeper is reused shallower", async () => {
+      // The long route resolves g at depth 3 with budget to spare.
+      // The short route then asks for g at depth 1, where there is
+      // strictly more headroom, so the entry is sound to reuse.
+      seedTwoDepths("longFirst");
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, { maxBreadth: 1 })).toBe(false);
+      expect(store.callsWith("findUsersetTuples", "group", "g", "member")).toBe(
+        1,
+      );
+    });
+
+    test("an entry recorded shallower is not reused deeper", async () => {
+      // Reversed order, and a budget that only the short route
+      // fits in: g at depth 1 reaches leaf at depth 2, but g at
+      // depth 3 would reach leaf at depth 4, which is out of
+      // budget. Reusing the depth-1 entry would answer `false`
+      // where a fresh resolution throws — so the deeper visit must
+      // recompute, and the error must surface.
+      seedTwoDepths("shortFirst");
+
+      await expect(
+        check(store, viewerRequest, { maxBreadth: 1, maxDepth: 4 }),
+      ).rejects.toBeInstanceOf(DepthExceededError);
+    });
+
+    test("the same graph resolves when the budget fits", async () => {
+      // Control for the previous test: one more level of budget
+      // and nothing throws, so the rejection above is about depth
+      // and not about the fixture being malformed.
+      seedTwoDepths("shortFirst");
+
+      expect(
+        await check(store, viewerRequest, { maxBreadth: 1, maxDepth: 5 }),
+      ).toBe(false);
+    });
+  });
+
+  describe("the memo does not outlive the request", () => {
+    test("a second check re-reads what the first resolved", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "shared",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+
+      await check(store, viewerRequest, SEQUENTIAL);
+      store.resetCounts();
+      await check(store, viewerRequest, SEQUENTIAL);
+
+      expect(store.callsWith("findUsersetTuples", "doc", "1", "shared")).toBe(
+        1,
+      );
+    });
+  });
+});

--- a/packages/core/tests/helpers/mock-store.ts
+++ b/packages/core/tests/helpers/mock-store.ts
@@ -19,13 +19,30 @@ export class MockTupleStore implements TupleStore {
   /** Store-call counts per method name, for round-trip assertions. */
   counts: Record<string, number> = {};
 
-  /** Reset all call counts (data is untouched). */
+  /**
+   * Ordered log of every store call with its arguments. `counts`
+   * is per-method only, so it cannot say *which* node was read —
+   * assertions about memoization need the identity, not the total.
+   */
+  calls: Array<{ method: string; args: unknown[] }> = [];
+
+  /** Reset all call counts and the call log (data is untouched). */
   resetCounts(): void {
     this.counts = {};
+    this.calls = [];
   }
 
-  private tally(method: string): void {
+  /** Count calls to `method` whose arguments start with `args`. */
+  callsWith(method: string, ...args: unknown[]): number {
+    return this.calls.filter(
+      (call) =>
+        call.method === method && args.every((arg, i) => call.args[i] === arg),
+    ).length;
+  }
+
+  private tally(method: string, ...args: unknown[]): void {
     this.counts[method] = (this.counts[method] ?? 0) + 1;
+    this.calls.push({ method, args });
   }
 
   async findDirectTuple(
@@ -35,7 +52,14 @@ export class MockTupleStore implements TupleStore {
     subjectType: string,
     subjectId: string,
   ): Promise<Tuple | null> {
-    this.tally("findDirectTuple");
+    this.tally(
+      "findDirectTuple",
+      objectType,
+      objectId,
+      relation,
+      subjectType,
+      subjectId,
+    );
     return (
       this.tuples.find(
         (t) =>
@@ -54,7 +78,7 @@ export class MockTupleStore implements TupleStore {
     objectId: string,
     relation: string,
   ): Promise<Tuple[]> {
-    this.tally("findUsersetTuples");
+    this.tally("findUsersetTuples", objectType, objectId, relation);
     return this.tuples.filter(
       (t) =>
         t.objectType === objectType &&
@@ -69,7 +93,7 @@ export class MockTupleStore implements TupleStore {
     objectId: string,
     relation: string,
   ): Promise<Tuple[]> {
-    this.tally("findTuplesByRelation");
+    this.tally("findTuplesByRelation", objectType, objectId, relation);
     return this.tuples.filter(
       (t) =>
         t.objectType === objectType &&
@@ -82,7 +106,7 @@ export class MockTupleStore implements TupleStore {
     objectType: string,
     relation: string,
   ): Promise<RelationConfig | null> {
-    this.tally("findRelationConfig");
+    this.tally("findRelationConfig", objectType, relation);
     return (
       this.relationConfigs.find(
         (c) => c.objectType === objectType && c.relation === relation,
@@ -93,7 +117,7 @@ export class MockTupleStore implements TupleStore {
   async findConditionDefinition(
     name: string,
   ): Promise<ConditionDefinition | null> {
-    this.tally("findConditionDefinition");
+    this.tally("findConditionDefinition", name);
     return this.conditionDefinitions.find((c) => c.name === name) ?? null;
   }
 
@@ -144,7 +168,7 @@ export class MockTupleStore implements TupleStore {
   }
 
   async listCandidateObjectIds(objectType: string): Promise<string[]> {
-    this.tally("listCandidateObjectIds");
+    this.tally("listCandidateObjectIds", objectType);
     const ids = new Set<string>();
     for (const t of this.tuples) {
       if (t.objectType === objectType) {
@@ -165,7 +189,7 @@ export class MockTupleStore implements TupleStore {
       subjectRelation: string | null;
     }>
   > {
-    this.tally("listDirectSubjects");
+    this.tally("listDirectSubjects", objectType, objectId, relation);
     return this.tuples
       .filter(
         (t) =>
@@ -197,7 +221,7 @@ export class MockTupleStore implements TupleStore {
     objectType: string,
     relation: string,
   ): Promise<boolean> {
-    this.tally("deleteRelationConfig");
+    this.tally("deleteRelationConfig", objectType, relation);
     const idx = this.relationConfigs.findIndex(
       (c) => c.objectType === objectType && c.relation === relation,
     );
@@ -223,7 +247,7 @@ export class MockTupleStore implements TupleStore {
   }
 
   async deleteConditionDefinition(name: string): Promise<boolean> {
-    this.tally("deleteConditionDefinition");
+    this.tally("deleteConditionDefinition", name);
     const idx = this.conditionDefinitions.findIndex((c) => c.name === name);
     if (idx >= 0) {
       this.conditionDefinitions.splice(idx, 1);


### PR DESCRIPTION
The check graph is a DAG explored as a tree: a node reached by two
routes is resolved twice, from scratch. This adds a request-scoped
memo so it is resolved once.

Only settled results are published, never in-flight promises.
Coalescing in-flight work deadlocks on a cross-branch cycle: paths
are copied per branch, so with `viewer impliedBy [a, b]`,
`a impliedBy [b]`, `b impliedBy [a]` at breadth >= 2, each sibling
ends up awaiting the other's entry. That shape is now a test.

Two guards make reuse sound, and both are load-bearing — each was
mutation-checked and fails a test of its own:

Indeterminate results are never published. A cycle-truncated
`false` is exactly the path-dependent case: it came back empty
because the subtree looped onto *this* path, and another route
would not have. The flag every operator already propagates is the
whole test. What survives is sound by induction — a grant is a
proof found, and a proof does not stop existing on another route;
an unflagged `false` means every branch was refuted with none
truncated and none errored, since errors reject rather than
resolve and the two operators that swallow a sibling error do so
only behind a definitive deny.

Reuse is gated on depth. An entry recorded at depth D resolved
without exhausting the budget, so at any depth <= D there is at
least as much headroom and the subtree resolves the same way.
Reusing it deeper could answer where a fresh resolution would
throw DepthExceededError, so the entry records the greatest depth
it was proved at. A throw is simply never recorded, which is also
how a depth-exhausted subtree stays out — nothing in-flight is
published, so unlike the store cache there is no promise to evict.

The memo nests rather than joining a key, since ids are not
charset-restricted. It carries the subject even though the subject
is invariant per request, because nothing in the types enforces
that and a future path varying it would make the memo wrong rather
than merely over-eager.

On measurement, this does less than the plan predicted, and the
reason is structural rather than a tuning problem. The plan
justified settled-only on the grounds that "cross-branch dedup on
the second visit is where shape (d)'s win lives". At the default
breadth there is no second visit: every node launches its children
at once, so a whole level is in flight before any of it settles
and every route misses. Shape (d) is unchanged at breadth 4 and
above; it drops 955 -> 79 store calls at breadth 1 and 955 -> 577
at breadth 2. Every other bench shape is unchanged.

It is kept because Phase 6 is where it pays: `listObjects` runs
its per-candidate checks sequentially, so a memo spanning the
whole call has each candidate after the first hit it for the
shared subtree. That is the number to measure there, rather than
crediting this commit with a win it has not produced.

MockTupleStore gains an ordered call log. `counts` is per-method
only and cannot say which node was read, which is precisely what
a memo assertion needs.
