### PR TITLE
Cut redundant store reads from check and listObjects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,11 @@ tsfga/
 │   │   ├── src/
 │   │   │   ├── index.ts             barrel: createTsfga() + re-exports
 │   │   │   ├── check.ts             5-step recursive check algorithm
+│   │   │   ├── list-objects.ts      listObjects candidate pool
 │   │   │   ├── conditions.ts        CEL condition evaluation
+│   │   │   ├── caching-store.ts     request-scoped config cache
 │   │   │   ├── contextual-store.ts  ContextualTupleStore wrapper
+│   │   │   ├── tuple-validation.ts  shared write/contextual checks
 │   │   │   ├── types.ts             All shared types
 │   │   │   ├── errors.ts            Error hierarchy
 │   │   │   └── store-interface.ts   TupleStore interface definition

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -71,6 +71,36 @@ releases may contain breaking changes).
   reports the same error on every run. As before, any error fails
   the whole call rather than dropping the offending object.
 
+- **A check no longer issues tuple reads the relation config
+  rules out.** Each node used to probe for a direct tuple, a
+  wildcard tuple and userset rows regardless of what the relation
+  admits. Each read is now gated on the config — the same
+  predicate `addTuple` applies, so a writable tuple is always a
+  findable one — cutting a wide-union benchmark from 3005 store
+  reads to 1004, a TTU fanout from 306 to 104, and the
+  200-candidate `listObjects` shape from 852 to 436.
+
+  **Behavior-visible.** A tuple the model does not admit — one
+  written straight to the database bypassing `addTuple`, or left
+  behind by a relation that has since narrowed its type list — is
+  no longer found, where before it granted access. Relation
+  configs are now load-bearing for the read path rather than
+  advisory. OpenFGA behaves the same way and rejects such a tuple
+  at write time; the change fails closed.
+
+  A read is skipped only on a positive exclusion: no config, or
+  `directlyAssignableTypes: null`, still reads everything. tsfga
+  therefore skips less than OpenFGA, which issues no reads at all
+  for a purely computed relation — tsfga encodes that as the same
+  `null` that means "unrestricted" and cannot tell the two apart.
+  Closing that gap would change what `null` means for writes too,
+  so it is left for its own change.
+
+  Ordering the config read before the tuple reads gives up the
+  single overlapping read wave, also unreleased. The cost is one
+  round-trip per relation per request, not per node, because
+  configs are cached for the request.
+
 ## 0.3.1 — 2026-08
 
 Maintenance release. No changes to the published code — the

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -52,6 +52,25 @@ releases may contain breaking changes).
   resolved. Long rewrite ladders are still bounded — by cycle
   detection, since one object has a finite set of relations.
 
+- **`listObjects` checks its candidates concurrently and shares
+  one request scope across them.** Each candidate used to get its
+  own relation-config cache and its own node memo, so N documents
+  behind one folder re-read every config N times and re-resolved
+  the shared subtree N times; they now span the whole call. The
+  serial loop is also gone — candidates run with at most
+  `maxBreadth` in flight, the same bound upstream uses for its
+  ListObjects pool. On a 200-candidate benchmark where 195 share
+  a three-node subtree this is 2361 store reads down to 852, and
+  395 config reads down to 2.
+
+  Two behaviors are now specified rather than incidental. The
+  returned array is in candidate order, which concurrency would
+  otherwise have scrambled. And when several candidates fail, the
+  error raised is the first failing candidate in *candidate*
+  order, not the first to fail in time — so a broken model
+  reports the same error on every run. As before, any error fails
+  the whole call rather than dropping the offending object.
+
 ## 0.3.1 — 2026-08
 
 Maintenance release. No changes to the published code — the

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -191,6 +191,46 @@ surfaces is deterministic: it is the first failing candidate in
 *candidate* order, not the first to fail in wall-clock order. No
 candidate after a failure is started.
 
+## Relation configs gate the reads
+
+Each node of a check can issue three tuple reads: a direct probe
+for the subject, a probe for a `type:*` wildcard, and a scan for
+userset rows. A read is skipped when the relation config says
+nothing it could find would be valid:
+
+| Read | Skipped when |
+|---|---|
+| direct probe | `directlyAssignableTypes` omits the subject type |
+| wildcard probe | `directlyAssignableTypes` omits `subjectType:*` |
+| userset scan | `allowsUsersetSubjects` is `false` |
+
+A read is skipped only on a *positive* exclusion. A relation with
+no config at all, or with `directlyAssignableTypes: null` — which
+means "not narrowed", not "purely computed" — still reads
+everything. The gate is the same predicate `addTuple` applies, so
+a tuple that can be written is always a tuple that can be found.
+
+**This makes relation configs load-bearing rather than
+advisory.** A tuple written straight to the database, bypassing
+`addTuple`, or left behind by a relation that has since narrowed
+its type list, is no longer found by `check` — it is treated as
+the invalid row it is. Previously it would have granted access.
+This matches OpenFGA, whose reads are typed and which rejects
+such a tuple at write time; the failure direction is closed, not
+open.
+
+The config for a relation is read once per request and cached, so
+this ordering costs one round-trip per relation, not per node.
+
+tsfga skips less than upstream in one case. A purely computed
+relation (`define viewer: owner`) issues no tuple reads at all in
+OpenFGA, which dispatches on the relation's rewrite. tsfga
+encodes "purely computed" as the same `directlyAssignableTypes:
+null` that also means "unrestricted", so it cannot tell the two
+apart and reads. Distinguishing them would mean changing what
+`null` means for writes as well, so it is deliberately not folded
+in here.
+
 ## Contextual tuples
 
 Contextual tuples passed on a `CheckRequest` are validated

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,7 +57,7 @@ const allowed = await fga.check({
 | `check(request)` | Check if a subject has a relation on an object |
 | `addTuple(request)` | Insert or update a relationship tuple |
 | `removeTuple(request)` | Delete a relationship tuple |
-| `listObjects(objectType, relation, subjectType, subjectId, context?)` | List object IDs the subject can access; `context` is forwarded to each check |
+| `listObjects(objectType, relation, subjectType, subjectId, context?)` | List object IDs the subject can access, in candidate order; `context` is forwarded to each check |
 | `listSubjects(objectType, objectId, relation)` | List direct subjects for an object + relation (no expansion) |
 | `writeRelationConfig(config)` | Insert or update a relation configuration |
 | `deleteRelationConfig(objectType, relation)` | Delete a relation configuration |
@@ -164,6 +164,32 @@ depends on completion order — the same nondeterminism OpenFGA
 has. Branches still queued when a node settles are never
 started. `maxBreadth` must be an integer >= 1 or `Infinity`;
 anything else throws `TsfgaError`.
+
+`maxBreadth` also bounds how many `listObjects` candidates are
+checked at once — the same knob deliberately, following
+upstream, whose ListObjects worker pool is sized at
+`1 + resolveNodeBreadthLimit`.
+
+## listObjects
+
+Candidates come from `listCandidateObjectIds`, which is only a
+pre-filter: every candidate still goes through a full `check`.
+All of those checks share one relation-config cache and one node
+memo for the whole call, so a subtree common to many objects —
+the folder behind a thousand documents — is resolved once rather
+than once per object, and each relation config is read once
+rather than once per object.
+
+The returned array is in candidate order, not completion order.
+That is a tsfga determinism choice rather than parity; upstream
+streams objects in whatever order its pool finishes them.
+
+An error in any candidate fails the whole call, `check`'s errors
+included — `DepthExceededError` in one object does not silently
+drop that object from the list, matching upstream. Which error
+surfaces is deterministic: it is the first failing candidate in
+*candidate* order, not the first to fail in wall-clock order. No
+candidate after a failure is started.
 
 ## Contextual tuples
 

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -3,7 +3,12 @@ import { evaluateTupleCondition } from "./conditions.ts";
 import { ContextualTupleStore } from "./contextual-store.ts";
 import { DepthExceededError, TsfgaError } from "./errors.ts";
 import type { TupleStore } from "./store-interface.ts";
-import { validateTupleWrite } from "./tuple-validation.ts";
+import {
+  admitsDirectSubject,
+  admitsUsersetSubjects,
+  directSubjectRef,
+  validateTupleWrite,
+} from "./tuple-validation.ts";
 import type {
   CheckOptions,
   CheckRequest,
@@ -11,8 +16,13 @@ import type {
   Tuple,
 } from "./types.ts";
 
-/** Results of the per-node tuple batch: direct, wildcard, userset. */
-type NodeReads = readonly [Tuple | null, Tuple | null, Tuple[]];
+/**
+ * Results of the per-node tuple batch: direct, wildcard, userset.
+ * A slot the relation config rules out is filled with the same
+ * empty value the store would have returned, so consumers never
+ * distinguish "not read" from "read, found nothing".
+ */
+type NodeReads = readonly [Tuple | null, Tuple | null, readonly Tuple[]];
 
 /**
  * Internal result of resolving one node.
@@ -405,19 +415,27 @@ async function resolveNode(
   visited: ReadonlySet<string>,
   memo: NodeMemo,
 ): Promise<CheckResult> {
-  // Speculatively start the tuple batch so it overlaps the config
-  // fetch: one round-trip wave per node instead of two. Some paths
-  // never await it (config error, or an intersection without a
-  // direct operand); the derived catch keeps such a rejection from
-  // going unhandled while awaiting callers still see the error.
-  const reads = readNodeTuples(store, request);
-  reads.catch(() => {});
-
-  // Fetch relation config once for use across all steps
+  // Fetch relation config once for use across all steps — and
+  // before the tuple reads, which are gated on it.
+  //
+  // The reads used to be started speculatively alongside this
+  // fetch, to keep a node to one round-trip wave. Ordering them
+  // costs far less than it looks: configs are cached for the whole
+  // request and the cache coalesces concurrent misses, so a real
+  // round-trip happens once per relation, not once per node. Every
+  // node after the first for a given relation still issues one
+  // wave, now a smaller one.
   const config = await store.findRelationConfig(
     request.objectType,
     request.relation,
   );
+
+  // Some paths never await the batch (config error, or an
+  // intersection without a direct operand); the derived catch
+  // keeps such a rejection from going unhandled while awaiting
+  // callers still see the error.
+  const reads = readNodeTuples(store, request, config);
+  reads.catch(() => {});
 
   // Base resolution: intersection replaces steps 1-5 when present
   const resolveBase = (): Promise<CheckResult> =>
@@ -504,36 +522,65 @@ async function resolveNode(
 }
 
 /**
- * Issue the three per-node tuple reads (direct probe, wildcard
- * probe, userset scan) as one batch. Started at node entry so
- * they overlap the relation-config fetch.
+ * Issue the per-node tuple reads (direct probe, wildcard probe,
+ * userset scan) as one batch, skipping any the relation config
+ * says cannot match.
+ *
+ * A read is skipped only when the config *positively excludes* it.
+ * No config, or a config that declines to narrow the relation
+ * (`directlyAssignableTypes: null`), reads everything. The gate is
+ * the same predicate the write path applies, imported from
+ * `tuple-validation.ts` rather than restated, so a tuple that can
+ * be written is always a tuple that can be found.
+ *
+ * This mirrors upstream, which builds `checkDirect`'s three
+ * handlers behind `shouldCheckDirectTuple`,
+ * `shouldCheckPublicAssignable` and a non-empty
+ * `DirectlyRelatedUsersets` (`internal/graph/check.go`). It is
+ * narrower than upstream in one way, noted in the README: a
+ * purely computed relation issues no reads at all there, whereas
+ * tsfga encodes "purely computed" as the same `null` that means
+ * "unrestricted", so it cannot tell the two apart.
  */
 function readNodeTuples(
   store: TupleStore,
   request: CheckRequest,
+  config: RelationConfig | null,
 ): Promise<NodeReads> {
+  const subjectRef = directSubjectRef(request.subjectType, request.subjectId);
+  const wildcardRef = `${request.subjectType}:*`;
+
   return Promise.all([
-    store.findDirectTuple(
-      request.objectType,
-      request.objectId,
-      request.relation,
-      request.subjectType,
-      request.subjectId,
-    ),
-    store.findDirectTuple(
-      request.objectType,
-      request.objectId,
-      request.relation,
-      request.subjectType,
-      "*",
-    ),
-    store.findUsersetTuples(
-      request.objectType,
-      request.objectId,
-      request.relation,
-    ),
+    admitsDirectSubject(config, subjectRef)
+      ? store.findDirectTuple(
+          request.objectType,
+          request.objectId,
+          request.relation,
+          request.subjectType,
+          request.subjectId,
+        )
+      : null,
+    admitsDirectSubject(config, wildcardRef)
+      ? store.findDirectTuple(
+          request.objectType,
+          request.objectId,
+          request.relation,
+          request.subjectType,
+          "*",
+        )
+      : null,
+    admitsUsersetSubjects(config)
+      ? store.findUsersetTuples(
+          request.objectType,
+          request.objectId,
+          request.relation,
+        )
+      : NO_TUPLES,
   ]);
 }
+
+/** Stand-in for a userset scan the config rules out. Never mutated. */
+const NO_TUPLES: readonly Tuple[] = [];
 
 /**
  * A tuple's condition as a union branch. Condition evaluation can

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -196,12 +196,45 @@ function memoSet(
  * branch's error surfaces depends on completion order — the same
  * nondeterminism OpenFGA has.
  */
+// `async` is load-bearing: `createCheckScope` validates
+// `maxBreadth` and throws, and an option error must reach the
+// caller as a rejection like every other check failure, not as a
+// synchronous throw past their `.catch`.
 export async function check(
   store: TupleStore,
   request: CheckRequest,
   options: CheckOptions = {},
 ): Promise<boolean> {
-  const maxDepth = options.maxDepth ?? 25;
+  return runCheck(createCheckScope(store, options), request);
+}
+
+/**
+ * The state one or more checks share: resolved limits, a caching
+ * store, and the node memo. A single check owns a scope of its
+ * own; `listObjects` builds one and runs every candidate in it,
+ * which is what makes the config cache and the memo span the whole
+ * call instead of being rebuilt per candidate.
+ *
+ * A scope is only sound across requests that resolve over the same
+ * graph. The memo keys on subject and node but *not* on the CEL
+ * `context`, and the caching store keys on nothing at all, so
+ * every request sharing a scope must carry the same `context`.
+ * Contextual tuples are the other half of that constraint and
+ * `runCheck` handles them itself, below.
+ *
+ * Internal. Not re-exported from `index.ts`.
+ */
+export interface CheckScope {
+  readonly store: TupleStore;
+  readonly maxDepth: number;
+  readonly maxBreadth: number;
+  readonly memo: NodeMemo;
+}
+
+export function createCheckScope(
+  store: TupleStore,
+  options: CheckOptions = {},
+): CheckScope {
   const maxBreadth = options.maxBreadth ?? 10;
   // The negated comparison also rejects NaN, which `< 1` misses.
   // Fractional values would admit one more branch than stated
@@ -216,20 +249,33 @@ export async function check(
     );
   }
 
-  // Request-scoped cache for relation configs and condition
-  // definitions: static per model, but read at every node.
-  const cachingStore = new CachingTupleStore(store);
+  return {
+    // Cache for relation configs and condition definitions: static
+    // per model, but read at every node.
+    store: new CachingTupleStore(store),
+    maxDepth: options.maxDepth ?? 25,
+    maxBreadth,
+    memo: new Map(),
+  };
+}
+
+/** Run one check in a scope. Internal; see `CheckScope`. */
+export async function runCheck(
+  scope: CheckScope,
+  request: CheckRequest,
+): Promise<boolean> {
+  let store = scope.store;
+  let memo = scope.memo;
 
   // Wrap store with contextual tuples for the whole request.
   // Contextual tuples must pass the same validation as addTuple.
-  let effectiveStore: TupleStore = cachingStore;
   if (request.contextualTuples?.length) {
     // Validate all contextual tuples concurrently; surface the
     // first failure in tuple order (not completion order) so the
     // thrown error is deterministic.
     const validations = await Promise.allSettled(
       request.contextualTuples.map((tuple) =>
-        validateTupleWrite(cachingStore, tuple),
+        validateTupleWrite(scope.store, tuple),
       ),
     );
     for (const validation of validations) {
@@ -237,20 +283,22 @@ export async function check(
         throw validation.reason;
       }
     }
-    effectiveStore = new ContextualTupleStore(
-      cachingStore,
-      request.contextualTuples,
-    );
+    store = new ContextualTupleStore(scope.store, request.contextualTuples);
+    // These tuples exist for this request only, so results resolved
+    // over them are not shareable — and results already in the
+    // scope's memo were resolved over a graph missing them. Neither
+    // direction is safe, so this request memoizes on its own.
+    memo = new Map();
   }
 
   const result = await checkNode(
-    effectiveStore,
+    store,
     request,
-    maxDepth,
-    maxBreadth,
+    scope.maxDepth,
+    scope.maxBreadth,
     0,
     new Set(),
-    new Map(),
+    memo,
   );
   // The indeterminacy flag is internal; a cycle at the root is an
   // ordinary deny to the caller, as it is on OpenFGA's wire.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import { check } from "./check.ts";
+import { listObjects } from "./list-objects.ts";
 import type { TupleStore } from "./store-interface.ts";
 import { validateTupleWrite } from "./tuple-validation.ts";
 import type {
@@ -31,6 +32,15 @@ export interface TsfgaClient {
    * check. Candidates come from `listCandidateObjectIds`
    * (pre-filter); the optional `context` is forwarded to each
    * per-object check for CEL condition evaluation.
+   *
+   * Candidates are checked concurrently, bounded by `maxBreadth`,
+   * and share one relation-config cache and one node memo for the
+   * whole call. The result is in candidate order.
+   *
+   * @throws whatever `check` throws for the first failing
+   *   candidate in candidate order — including
+   *   `DepthExceededError`, which aborts the whole call rather
+   *   than dropping that one object.
    */
   listObjects(
     objectType: string,
@@ -75,26 +85,22 @@ export function createTsfga(
       return store.deleteTuple(request);
     },
 
-    async listObjects(
+    listObjects(
       objectType: string,
       relation: string,
       subjectType: string,
       subjectId: string,
       context?: Record<string, unknown>,
     ): Promise<string[]> {
-      const candidateIds = await store.listCandidateObjectIds(objectType);
-      const results: string[] = [];
-      for (const objectId of candidateIds) {
-        const allowed = await check(
-          store,
-          { objectType, objectId, relation, subjectType, subjectId, context },
-          options,
-        );
-        if (allowed) {
-          results.push(objectId);
-        }
-      }
-      return results;
+      return listObjects(
+        store,
+        objectType,
+        relation,
+        subjectType,
+        subjectId,
+        context,
+        options,
+      );
     },
 
     listSubjects(

--- a/packages/core/src/list-objects.ts
+++ b/packages/core/src/list-objects.ts
@@ -1,0 +1,162 @@
+import { createCheckScope, runCheck } from "./check.ts";
+import type { TupleStore } from "./store-interface.ts";
+import type { CheckOptions } from "./types.ts";
+
+/**
+ * List object IDs of a type for which the subject passes a full
+ * check.
+ *
+ * Candidates come from `listCandidateObjectIds` (a pre-filter —
+ * every candidate is still checked). All of them are checked in
+ * one `CheckScope`, so the relation-config cache and the node memo
+ * span the whole call: the shared subtree behind N documents is
+ * resolved once rather than N times.
+ *
+ * Concurrency is bounded by `maxBreadth`. That is the same knob as
+ * per-node branch fanout by design, not by accident: upstream
+ * sizes its ListObjects worker pool at
+ * `1 + resolveNodeBreadthLimit` and hands the same limit down to
+ * the reverse-expand query
+ * (`pkg/server/commands/list_objects.go`).
+ *
+ * Errors: the first failing candidate *in candidate order* is
+ * thrown, not the first to fail in wall-clock order — no candidate
+ * after a failure is started, but every candidate before one is
+ * awaited, so the error a broken model produces is reproducible.
+ * Any error aborts the whole call, including
+ * `DepthExceededError`; upstream likewise maps a depth-exceeded
+ * candidate to a failed ListObjects rather than dropping that
+ * object (`list_objects.go`, `ErrAuthorizationModelResolutionTooComplex`).
+ *
+ * The returned array is in candidate order. That is a tsfga
+ * determinism choice rather than parity — upstream streams objects
+ * in completion order from its pool.
+ */
+export async function listObjects(
+  store: TupleStore,
+  objectType: string,
+  relation: string,
+  subjectType: string,
+  subjectId: string,
+  context?: Record<string, unknown>,
+  options: CheckOptions = {},
+): Promise<string[]> {
+  const scope = createCheckScope(store, options);
+  const candidateIds = await store.listCandidateObjectIds(objectType);
+
+  return resolveCandidates(candidateIds, scope.maxBreadth, (objectId) =>
+    runCheck(scope, {
+      objectType,
+      objectId,
+      relation,
+      subjectType,
+      subjectId,
+      context,
+    }),
+  );
+}
+
+/**
+ * Run `check` over candidates with at most `maxBreadth` in flight,
+ * preserving candidate order in the result.
+ *
+ * Same pull model as the node combinator in `check.ts`: handlers
+ * launch in order while there is a free slot, and each settlement
+ * pulls the next. It cannot share that combinator because this one
+ * collects every result instead of short-circuiting on the first
+ * decisive one.
+ *
+ * On failure it stops launching but still awaits what is already
+ * in flight, then rejects with the lowest-index failure seen. That
+ * is deterministic: launching is in index order, so when a
+ * candidate at index `f` fails, every index below `f` has already
+ * been launched and will be awaited — including the true lowest
+ * failing index, which is therefore always the one reported,
+ * whatever the completion order was.
+ */
+function resolveCandidates(
+  candidateIds: readonly string[],
+  maxBreadth: number,
+  run: (objectId: string) => Promise<boolean>,
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const allowed = new Array<boolean>(candidateIds.length).fill(false);
+    let next = 0;
+    let active = 0;
+    let settled = false;
+    // Also the launch cut-off: nothing at or beyond it is started.
+    let failedIndex = candidateIds.length;
+    let failure: unknown;
+
+    const record = (index: number, error: unknown) => {
+      if (index < failedIndex) {
+        failedIndex = index;
+        failure = error;
+      }
+    };
+
+    const launch = () => {
+      while (
+        !settled &&
+        active < maxBreadth &&
+        next < candidateIds.length &&
+        next < failedIndex
+      ) {
+        const index = next;
+        next++;
+        const objectId = candidateIds[index];
+        if (objectId === undefined) continue;
+        active++;
+        let candidate: Promise<boolean>;
+        try {
+          candidate = run(objectId);
+        } catch (error) {
+          // A synchronous throw counts as a failed candidate;
+          // without this its slot would leak and the pool could
+          // stall with nothing in flight.
+          active--;
+          record(index, error);
+          continue;
+        }
+        candidate.then(
+          (result) => {
+            if (settled) return;
+            allowed[index] = result;
+            onCandidateDone();
+          },
+          (error) => {
+            if (settled) return;
+            record(index, error);
+            onCandidateDone();
+          },
+        );
+      }
+      // No candidates, holes, and synchronous throws can exhaust
+      // the launch loop with nothing in flight; settle here so the
+      // returned promise can never stall.
+      if (!settled && active === 0) {
+        settleExhausted();
+      }
+    };
+
+    const onCandidateDone = () => {
+      active--;
+      if (next < candidateIds.length && next < failedIndex) {
+        launch();
+      } else if (active === 0) {
+        settleExhausted();
+      }
+    };
+
+    const settleExhausted = () => {
+      settled = true;
+      if (failedIndex < candidateIds.length) {
+        reject(failure);
+      } else {
+        resolve(candidateIds.filter((_, index) => allowed[index]));
+      }
+    };
+
+    launch();
+  });
+}

--- a/packages/core/src/tuple-validation.ts
+++ b/packages/core/src/tuple-validation.ts
@@ -4,7 +4,46 @@ import {
   UsersetNotAllowedError,
 } from "./errors.ts";
 import type { TupleStore } from "./store-interface.ts";
-import type { AddTupleRequest } from "./types.ts";
+import type { AddTupleRequest, RelationConfig } from "./types.ts";
+
+/**
+ * How a subject appears in `directlyAssignableTypes`: bare for an
+ * ordinary subject, `type:*` for a wildcard one.
+ */
+export function directSubjectRef(
+  subjectType: string,
+  subjectId: string,
+): string {
+  return subjectId === "*" ? `${subjectType}:*` : subjectType;
+}
+
+/**
+ * Whether the relation can hold a direct tuple for `subjectRef`.
+ *
+ * A `null` `directlyAssignableTypes` means *unrestricted*, not
+ * *none* — the config declines to narrow the relation rather than
+ * declaring it purely computed.
+ *
+ * The check algorithm gates its tuple reads on this same
+ * predicate, which is why it lives here next to the write path
+ * rather than in `check.ts`. The two must agree exactly: a read
+ * gate stricter than the write gate would accept a tuple and then
+ * never find it again.
+ */
+export function admitsDirectSubject(
+  config: RelationConfig | null,
+  subjectRef: string,
+): boolean {
+  const allowed = config?.directlyAssignableTypes;
+  return !allowed || allowed.includes(subjectRef);
+}
+
+/** Whether the relation can hold userset (`object#relation`) rows. */
+export function admitsUsersetSubjects(config: RelationConfig | null): boolean {
+  // Unlike the type list this is a required boolean, so `false` is
+  // always a positive exclusion and there is no null case.
+  return config === null || config.allowsUsersetSubjects;
+}
 
 /**
  * Validate that a tuple is writable under the relation's config.
@@ -30,22 +69,17 @@ export async function validateTupleWrite(
     throw new RelationConfigNotFoundError(request.objectType, request.relation);
   }
 
-  if (config.directlyAssignableTypes) {
-    const subjectRef =
-      request.subjectId === "*"
-        ? `${request.subjectType}:*`
-        : request.subjectType;
-    if (!config.directlyAssignableTypes.includes(subjectRef)) {
-      throw new InvalidSubjectTypeError(
-        subjectRef,
-        request.objectType,
-        request.relation,
-        config.directlyAssignableTypes,
-      );
-    }
+  const subjectRef = directSubjectRef(request.subjectType, request.subjectId);
+  if (!admitsDirectSubject(config, subjectRef)) {
+    throw new InvalidSubjectTypeError(
+      subjectRef,
+      request.objectType,
+      request.relation,
+      config.directlyAssignableTypes ?? [],
+    );
   }
 
-  if (request.subjectRelation && !config.allowsUsersetSubjects) {
+  if (request.subjectRelation && !admitsUsersetSubjects(config)) {
     throw new UsersetNotAllowedError(request.objectType, request.relation);
   }
 }

--- a/packages/core/tests/check-concurrency.test.ts
+++ b/packages/core/tests/check-concurrency.test.ts
@@ -134,16 +134,24 @@ class SlowConfigStore extends MockTupleStore {
   }
 }
 
-describe("single-wave node reads", () => {
-  test("config fetch and tuple reads are issued concurrently", async () => {
+describe("node read waves", () => {
+  /** A relation that admits all three reads, so none is gated out. */
+  function wideOpenConfig(relation: string): RelationConfig {
+    return makeConfig({
+      objectType: "doc",
+      relation,
+      directlyAssignableTypes: ["user", "user:*"],
+      allowsUsersetSubjects: true,
+    });
+  }
+
+  test("the admitted tuple reads are issued as one wave", async () => {
+    // The config read no longer overlaps them: the reads are
+    // gated on what the config admits, so it has to land first.
+    // What is still asserted is that the reads it does admit go
+    // out together rather than one at a time.
     const store = new GatedStore();
-    store.relationConfigs.push(
-      makeConfig({
-        objectType: "doc",
-        relation: "viewer",
-        directlyAssignableTypes: ["user"],
-      }),
-    );
+    store.relationConfigs.push(wideOpenConfig("viewer"));
 
     const result = await check(store, {
       objectType: "doc",
@@ -154,12 +162,86 @@ describe("single-wave node reads", () => {
     });
 
     expect(result).toBe(false);
-    // One node issues 4 reads (config, direct, wildcard, userset)
-    // in a single overlapping wave.
-    expect(store.highWater).toBe(4);
+    expect(store.highWater).toBe(3);
   });
 
-  test("config-read error surfaces after tuple reads resolve", async () => {
+  test("a second node of the same relation pays no config read", async () => {
+    // The cost of ordering the config before the reads is one
+    // round-trip per relation per request, not per node — this is
+    // what makes that trade cheap enough to take. `outer` implies
+    // `inner`, so two nodes resolve but `doc.inner` is read once.
+    const store = new MockTupleStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "outer",
+        impliedBy: ["inner", "inner2"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "inner",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "inner",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+    store.resetCounts();
+
+    // Two objects, so `doc.inner` is resolved as a node twice.
+    for (const objectId of ["1", "2"]) {
+      await check(
+        store,
+        {
+          objectType: "doc",
+          objectId,
+          relation: "inner",
+          subjectType: "user",
+          subjectId: "alice",
+        },
+        { maxBreadth: 1 },
+      );
+    }
+    // Two separate requests, so two config reads — not four.
+    expect(store.callsWith("findRelationConfig", "doc", "inner")).toBe(2);
+  });
+
+  test("skipped reads do not stall the wave", async () => {
+    // A gated-out slot is filled synchronously. If it were left
+    // as a pending promise the batch would never settle.
+    const store = new GatedStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+
+    expect(
+      await check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).toBe(false);
+    // Only the subject's direct probe survives the gate: no
+    // `user:*` in the type list, and no userset subjects.
+    expect(store.highWater).toBe(1);
+  });
+
+  test("a config-read error fails the node", async () => {
+    // The reads are gated on the config, so a failed config read
+    // means they are never issued at all — but the error the
+    // caller sees is the same one as when they raced it.
     const store = new DelayedConfigErrorStore();
     store.tuples.push(
       makeTuple({
@@ -229,9 +311,10 @@ describe("single-wave node reads", () => {
     });
 
     expect(result).toBe(true);
-    // Only the root node's probes; the 3 userset branches would
-    // each have added 2 more findDirectTuple calls.
-    expect(store.counts.findDirectTuple).toBe(2);
+    // Only the root node's subject probe; the wildcard probe is
+    // gated out (no `user:*` in the type list) and the 3 userset
+    // branches would each have added one more.
+    expect(store.counts.findDirectTuple).toBe(1);
     expect(store.counts.findUsersetTuples).toBe(1);
   });
 
@@ -378,8 +461,10 @@ describe("single-wave node reads", () => {
     });
 
     expect(result).toBe(true);
-    // Root probes (2) plus 2 probes per launched userset branch.
-    expect(store.counts.findDirectTuple).toBe(8);
+    // One root probe plus one per launched userset branch. Was 8
+    // before the read gating: every node also probed for a
+    // `user:*` tuple that neither type list admits.
+    expect(store.counts.findDirectTuple).toBe(4);
   });
 
   test("surfaced error follows completion order across branches", async () => {
@@ -424,15 +509,22 @@ describe("single-wave node reads", () => {
     ).rejects.toBeInstanceOf(StoreReadFailure);
   });
 
-  test("tuples sampled before a mid-request config swap deny", async () => {
-    // Accepted staleness: the tuple batch overlaps the config
-    // fetch, so a node can pair older tuples with a newer config
-    // and deny where strict config-then-tuples ordering granted.
-    // Fail-closed direction only — a grant read at time t implies
-    // the store granted at time t. OpenFGA cannot express this
-    // scenario at all: a request resolves against one immutable
-    // model snapshot, which mutable relation configs approximate
-    // via the request-scoped config cache.
+  test("a mid-request config swap is read before its tuples", async () => {
+    // This used to deny. While the tuple batch overlapped the
+    // config fetch, a node could pair pre-migration tuples with a
+    // post-migration config; that was accepted as fail-closed
+    // staleness. Gating the reads on the config restores strict
+    // config-then-tuples ordering, so the node now sees both
+    // halves of the migration and grants — which is also the
+    // better answer, since every instantaneous snapshot of the
+    // store grants alice.
+    //
+    // Still not a guarantee, just a narrower window: the config is
+    // sampled once per relation per request, so a swap between two
+    // relations' samplings is unchanged. OpenFGA cannot express
+    // the scenario at all — a request resolves against one
+    // immutable model snapshot, which mutable relation configs
+    // approximate via the request-scoped config cache.
     class MigratingStore extends MockTupleStore {
       override async findRelationConfig(
         objectType: string,
@@ -484,10 +576,6 @@ describe("single-wave node reads", () => {
       }),
     );
 
-    // Every instantaneous snapshot grants alice, and the old
-    // config-then-tuples order returned true; the overlapping
-    // waves pair pre-migration tuples with the post-migration
-    // config and deny.
     expect(
       await check(store, {
         objectType: "doc",
@@ -496,7 +584,7 @@ describe("single-wave node reads", () => {
         subjectType: "user",
         subjectId: "alice",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 

--- a/packages/core/tests/check-memo.test.ts
+++ b/packages/core/tests/check-memo.test.ts
@@ -34,6 +34,16 @@ function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
 }
 
 /**
+ * These tests count `findDirectTuple` for the subject as the
+ * "this node was resolved" signal. It used to be
+ * `findUsersetTuples`, which read better, but the read gating
+ * skips the userset scan on any relation that forbids userset
+ * subjects — which is most of the fixtures here — so that call no
+ * longer happens once per node visit. The subject's direct probe
+ * does, on every relation these fixtures declare. The extra
+ * subject arguments matter: a node also probes for a wildcard, and
+ * `callsWith` on the object alone would count both.
+ *
  * Every test here runs at `maxBreadth: 1` unless it says otherwise.
  * The memo publishes settled results only — never in-flight
  * promises, which would deadlock when two sibling branches each
@@ -93,9 +103,16 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "shared")).toBe(
-        1,
-      );
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "shared",
+          "user",
+          "alice",
+        ),
+      ).toBe(1);
     });
 
     test("a definitive true is served from the memo", async () => {
@@ -119,10 +136,26 @@ describe("request-scoped node memoization", () => {
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(true);
       // `left` grants and the union stops, so `shared` is read once
       // — by `left`, never by `right`.
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "shared")).toBe(
-        1,
-      );
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "right")).toBe(0);
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "shared",
+          "user",
+          "alice",
+        ),
+      ).toBe(1);
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "right",
+          "user",
+          "alice",
+        ),
+      ).toBe(0);
     });
 
     test("without a shared node nothing is deduplicated", async () => {
@@ -148,8 +181,12 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "l2")).toBe(1);
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "r2")).toBe(1);
+      expect(
+        store.callsWith("findDirectTuple", "doc", "1", "l2", "user", "alice"),
+      ).toBe(1);
+      expect(
+        store.callsWith("findDirectTuple", "doc", "1", "r2", "user", "alice"),
+      ).toBe(1);
     });
   });
 
@@ -171,8 +208,12 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "x")).toBe(2);
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "p")).toBe(2);
+      expect(
+        store.callsWith("findDirectTuple", "doc", "1", "x", "user", "alice"),
+      ).toBe(2);
+      expect(
+        store.callsWith("findDirectTuple", "doc", "1", "p", "user", "alice"),
+      ).toBe(2);
     });
 
     test("a cross-branch cycle terminates instead of deadlocking", async () => {
@@ -281,9 +322,16 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, { maxBreadth: 1 })).toBe(false);
-      expect(store.callsWith("findUsersetTuples", "group", "g", "member")).toBe(
-        1,
-      );
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "group",
+          "g",
+          "member",
+          "user",
+          "alice",
+        ),
+      ).toBe(1);
     });
 
     test("an entry recorded shallower is not reused deeper", async () => {
@@ -331,9 +379,16 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
       await check(store, viewerRequest, SEQUENTIAL);
 
-      expect(store.callsWith("findUsersetTuples", "doc", "1", "shared")).toBe(
-        1,
-      );
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "shared",
+          "user",
+          "alice",
+        ),
+      ).toBe(1);
     });
   });
 });

--- a/packages/core/tests/list-objects.test.ts
+++ b/packages/core/tests/list-objects.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import { DepthExceededError } from "../src/errors.ts";
+import { createTsfga } from "../src/index.ts";
+import { listObjects } from "../src/list-objects.ts";
+import type { RelationConfig, Tuple } from "../src/types.ts";
+import { delay, StoreReadFailure } from "./helpers/erroring-store.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Every candidate check opens with a direct-tuple read on the
+ * candidate object, which makes that read a usable proxy for "this
+ * candidate has started". Stalling it parks each candidate at a
+ * point where the pool's concurrency is observable, and failing it
+ * fails exactly one candidate without disturbing the shared
+ * subtree behind them all.
+ */
+class CandidateStore extends MockTupleStore {
+  inFlight = 0;
+  peakInFlight = 0;
+  started: string[] = [];
+  /** Candidate object id -> the failure its check should raise. */
+  failures = new Map<string, Error>();
+  /** Candidate object id -> ms to stall before settling. */
+  delays = new Map<string, number>();
+
+  override async findDirectTuple(
+    objectType: string,
+    objectId: string,
+    relation: string,
+    subjectType: string,
+    subjectId: string,
+  ): Promise<Tuple | null> {
+    // A node reads its direct tuple and its wildcard tuple in one
+    // wave; instrument only the former, so one candidate counts
+    // as one in flight.
+    if (objectType !== "doc" || subjectId === "*") {
+      return super.findDirectTuple(
+        objectType,
+        objectId,
+        relation,
+        subjectType,
+        subjectId,
+      );
+    }
+    this.started.push(objectId);
+    this.inFlight++;
+    this.peakInFlight = Math.max(this.peakInFlight, this.inFlight);
+    try {
+      await delay(this.delays.get(objectId) ?? 1);
+      const failure = this.failures.get(objectId);
+      if (failure) {
+        throw failure;
+      }
+      return await super.findDirectTuple(
+        objectType,
+        objectId,
+        relation,
+        subjectType,
+        subjectId,
+      );
+    } finally {
+      this.inFlight--;
+    }
+  }
+}
+
+/** The thrown error's message, or a marker when nothing threw. */
+async function failureMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  return "<resolved>";
+}
+
+describe("listObjects", () => {
+  let store: CandidateStore;
+
+  /**
+   * Many documents, one shared subtree behind all of them.
+   *
+   *   doc:N#viewer --TTU parent--> folder:shared#member
+   *   folder:shared#member --userset--> folder:sub#member
+   *
+   * Nothing grants, so no candidate short-circuits and every one
+   * of them walks the whole shared subtree.
+   */
+  function seedSharedSubtree(candidates: number) {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        tupleToUserset: [{ tupleset: "parent", computedUserset: "member" }],
+      }),
+      makeConfig({
+        objectType: "folder",
+        relation: "member",
+        directlyAssignableTypes: ["user", "folder"],
+        allowsUsersetSubjects: true,
+      }),
+    );
+    for (let i = 1; i <= candidates; i++) {
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: String(i),
+          relation: "parent",
+          subjectType: "folder",
+          subjectId: "shared",
+        }),
+      );
+    }
+    store.tuples.push(
+      makeTuple({
+        objectType: "folder",
+        objectId: "shared",
+        relation: "member",
+        subjectType: "folder",
+        subjectId: "sub",
+        subjectRelation: "member",
+      }),
+    );
+  }
+
+  const docIds = (count: number) =>
+    Array.from({ length: count }, (_, i) => String(i + 1));
+
+  beforeEach(() => {
+    store = new CandidateStore();
+  });
+
+  describe("the request scope spans the whole call", () => {
+    test("relation configs are fetched once, not once per candidate", async () => {
+      // Independent of concurrency: the caching store is built by
+      // the scope, so it is shared however the candidates overlap.
+      seedSharedSubtree(5);
+      store.resetCounts();
+
+      await listObjects(store, "doc", "viewer", "user", "alice");
+
+      expect(store.callsWith("findRelationConfig", "doc", "viewer")).toBe(1);
+      expect(store.callsWith("findRelationConfig", "folder", "member")).toBe(1);
+    });
+
+    test("a shared subtree resolves once for the whole call", async () => {
+      // At breadth 1 the candidates are sequential, so each one
+      // after the first finds the subtree already settled in the
+      // memo. See the control below for what this replaces.
+      seedSharedSubtree(5);
+      store.resetCounts();
+
+      await listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+        maxBreadth: 1,
+      });
+
+      expect(
+        store.callsWith("findUsersetTuples", "folder", "shared", "member"),
+      ).toBe(1);
+    });
+
+    test("control: separate checks each re-resolve the subtree", async () => {
+      // The same five objects checked one call at a time — which
+      // is what listObjects did before the scope was hoisted.
+      // Without this, the count above could just mean the fixture
+      // is too small to share anything.
+      seedSharedSubtree(5);
+      store.resetCounts();
+
+      for (const objectId of docIds(5)) {
+        await check(
+          store,
+          {
+            objectType: "doc",
+            objectId,
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+          },
+          { maxBreadth: 1 },
+        );
+      }
+
+      expect(
+        store.callsWith("findUsersetTuples", "folder", "shared", "member"),
+      ).toBe(5);
+    });
+  });
+
+  describe("candidate concurrency is bounded by maxBreadth", () => {
+    test("at most maxBreadth candidates are in flight", async () => {
+      seedSharedSubtree(8);
+      // Long enough that all eight would overlap if unbounded.
+      for (const id of docIds(8)) store.delays.set(id, 10);
+
+      await listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+        maxBreadth: 3,
+      });
+
+      expect(store.peakInFlight).toBe(3);
+    });
+
+    test("breadth 1 runs candidates one at a time", async () => {
+      seedSharedSubtree(4);
+
+      await listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+        maxBreadth: 1,
+      });
+
+      expect(store.peakInFlight).toBe(1);
+    });
+
+    test("an invalid maxBreadth rejects rather than throwing", async () => {
+      seedSharedSubtree(2);
+
+      await expect(
+        listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+          maxBreadth: 0,
+        }),
+      ).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe("results are in candidate order", () => {
+    test("a slow early candidate still comes first", async () => {
+      // Grant the first and last candidate, and make the first the
+      // slowest, so completion order and candidate order disagree.
+      seedSharedSubtree(4);
+      for (const objectId of ["1", "4"]) {
+        store.tuples.push(
+          makeTuple({
+            objectType: "doc",
+            objectId,
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+          }),
+        );
+      }
+      store.delays.set("1", 20);
+      store.delays.set("4", 1);
+
+      expect(
+        await listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+          maxBreadth: 4,
+        }),
+      ).toEqual(["1", "4"]);
+    });
+  });
+
+  describe("error contract", () => {
+    test("the lowest-index failure wins, not the first to fail", async () => {
+      // Candidate 4 fails immediately, candidate 2 slowly. Both
+      // are in flight together at breadth 4, so completion order
+      // reports 4 — candidate order must still report 2.
+      seedSharedSubtree(4);
+      store.failures.set("2", new StoreReadFailure("doc:2 failed"));
+      store.failures.set("4", new StoreReadFailure("doc:4 failed"));
+      store.delays.set("2", 20);
+      store.delays.set("4", 1);
+
+      expect(
+        await failureMessage(
+          listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+            maxBreadth: 4,
+          }),
+        ),
+      ).toBe("doc:2 failed");
+    });
+
+    test("no candidate after a failure is started", async () => {
+      seedSharedSubtree(5);
+      store.failures.set("2", new StoreReadFailure("doc:2 failed"));
+
+      await failureMessage(
+        listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+          maxBreadth: 1,
+        }),
+      );
+
+      expect(store.started).toEqual(["1", "2"]);
+    });
+
+    test("a granted candidate does not mask a later failure", async () => {
+      // Fail closed: a partial list is not a valid answer, so the
+      // grant on candidate 1 must not turn the call into `["1"]`.
+      seedSharedSubtree(3);
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+      store.failures.set("3", new StoreReadFailure("doc:3 failed"));
+
+      expect(
+        await failureMessage(
+          listObjects(store, "doc", "viewer", "user", "alice"),
+        ),
+      ).toBe("doc:3 failed");
+    });
+
+    test("depth exhaustion aborts the whole call", async () => {
+      // Upstream maps a depth-exceeded candidate to a failed
+      // ListObjects rather than silently dropping that object.
+      seedSharedSubtree(3);
+
+      await expect(
+        listObjects(store, "doc", "viewer", "user", "alice", undefined, {
+          maxDepth: 1,
+        }),
+      ).rejects.toBeInstanceOf(DepthExceededError);
+    });
+  });
+
+  describe("no candidates", () => {
+    test("an empty candidate list resolves to an empty array", async () => {
+      // The pool must settle with nothing ever launched rather
+      // than hanging on a promise no callback will resolve.
+      expect(
+        await listObjects(store, "doc", "viewer", "user", "alice"),
+      ).toEqual([]);
+    });
+  });
+
+  describe("through the client", () => {
+    test("createTsfga forwards its options to the candidate pool", async () => {
+      seedSharedSubtree(6);
+      for (const id of docIds(6)) store.delays.set(id, 10);
+
+      await createTsfga(store, { maxBreadth: 2 }).listObjects(
+        "doc",
+        "viewer",
+        "user",
+        "alice",
+      );
+
+      expect(store.peakInFlight).toBe(2);
+    });
+  });
+});

--- a/packages/core/tests/read-gating.test.ts
+++ b/packages/core/tests/read-gating.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import { InvalidSubjectTypeError } from "../src/errors.ts";
+import { validateTupleWrite } from "../src/tuple-validation.ts";
+import type { RelationConfig, Tuple } from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+const request = {
+  objectType: "doc",
+  objectId: "1",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "alice",
+};
+
+describe("structurally impossible reads are skipped", () => {
+  let store: MockTupleStore;
+
+  beforeEach(() => {
+    store = new MockTupleStore();
+  });
+
+  /** Push a `doc.viewer` config and run one check against it. */
+  async function checkWith(config: Partial<RelationConfig>) {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "viewer", ...config }),
+    );
+    store.resetCounts();
+    return check(store, request);
+  }
+
+  describe("each read is gated on its own declaration", () => {
+    test("a type list without the subject skips its probe", async () => {
+      await checkWith({ directlyAssignableTypes: ["team"] });
+
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "viewer",
+          "user",
+          "alice",
+        ),
+      ).toBe(0);
+    });
+
+    test("a type list with the subject keeps its probe", async () => {
+      await checkWith({ directlyAssignableTypes: ["user"] });
+
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "viewer",
+          "user",
+          "alice",
+        ),
+      ).toBe(1);
+    });
+
+    test("no `type:*` in the list skips the wildcard probe", async () => {
+      await checkWith({ directlyAssignableTypes: ["user"] });
+
+      expect(
+        store.callsWith("findDirectTuple", "doc", "1", "viewer", "user", "*"),
+      ).toBe(0);
+    });
+
+    test("`type:*` in the list keeps the wildcard probe", async () => {
+      await checkWith({ directlyAssignableTypes: ["user", "user:*"] });
+
+      expect(
+        store.callsWith("findDirectTuple", "doc", "1", "viewer", "user", "*"),
+      ).toBe(1);
+    });
+
+    test("forbidding userset subjects skips the userset scan", async () => {
+      await checkWith({ allowsUsersetSubjects: false });
+
+      expect(store.counts.findUsersetTuples).toBe(undefined);
+    });
+
+    test("allowing userset subjects keeps the userset scan", async () => {
+      await checkWith({ allowsUsersetSubjects: true });
+
+      expect(store.counts.findUsersetTuples).toBe(1);
+    });
+  });
+
+  describe("only a positive exclusion skips a read", () => {
+    test("a null type list reads both probes", async () => {
+      // `null` means the config declines to narrow the relation,
+      // not that the relation is purely computed. Reading it as
+      // "none" would skip probes for tuples `addTuple` accepts.
+      await checkWith({ directlyAssignableTypes: null });
+
+      expect(store.counts.findDirectTuple).toBe(2);
+    });
+
+    test("no config at all reads everything", async () => {
+      store.resetCounts();
+
+      await check(store, request);
+
+      expect(store.counts.findDirectTuple).toBe(2);
+      expect(store.counts.findUsersetTuples).toBe(1);
+    });
+  });
+
+  describe("the read gate matches the write gate", () => {
+    // The two must agree or a tuple could be written and then
+    // never found. These walk the same configs through both paths
+    // and require the same verdict.
+    const configs: Array<[string, Partial<RelationConfig>]> = [
+      ["null type list", { directlyAssignableTypes: null }],
+      ["subject listed", { directlyAssignableTypes: ["user"] }],
+      ["subject absent", { directlyAssignableTypes: ["team"] }],
+      ["wildcard only", { directlyAssignableTypes: ["user:*"] }],
+      ["both forms", { directlyAssignableTypes: ["user", "user:*"] }],
+      ["empty list", { directlyAssignableTypes: [] }],
+    ];
+
+    for (const [name, config] of configs) {
+      test(`${name}: a writable tuple is always findable`, async () => {
+        const full = makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          ...config,
+        });
+        store.relationConfigs.push(full);
+
+        const writable = await validateTupleWrite(store, {
+          ...request,
+        }).then(
+          () => true,
+          (error: unknown) => {
+            if (error instanceof InvalidSubjectTypeError) return false;
+            throw error;
+          },
+        );
+        if (!writable) return;
+
+        // Writable, so the check must actually look for it.
+        store.tuples.push(makeTuple({ ...request }));
+        store.resetCounts();
+
+        expect(await check(store, request)).toBe(true);
+      });
+    }
+  });
+
+  describe("a tuple the model does not admit is ignored", () => {
+    test("a stray direct tuple no longer grants", async () => {
+      // Written straight to the store, bypassing addTuple — or
+      // left behind by a config that has since narrowed. Upstream
+      // never sees such a row because the read is typed; tsfga
+      // now skips it for the same reason. Fail-closed.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["team"],
+        }),
+      );
+      store.tuples.push(makeTuple({ ...request }));
+
+      expect(await check(store, request)).toBe(false);
+    });
+
+    test("a stray userset tuple no longer grants", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["team"],
+          allowsUsersetSubjects: false,
+        }),
+        makeConfig({
+          objectType: "team",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "team",
+          subjectId: "t1",
+          subjectRelation: "member",
+        }),
+        makeTuple({
+          objectType: "team",
+          objectId: "t1",
+          relation: "member",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(await check(store, request)).toBe(false);
+    });
+  });
+
+  describe("gating does not disturb the rewrite steps", () => {
+    test("a computed relation still resolves with no reads of its own", async () => {
+      // `viewer` admits nothing directly, so all three of its
+      // reads are gated out — but it still rewrites to `owner`,
+      // which does read.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: [],
+          computedUserset: "owner",
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "owner",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(makeTuple({ ...request, relation: "owner" }));
+      store.resetCounts();
+
+      expect(await check(store, request)).toBe(true);
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "viewer",
+          "user",
+          "alice",
+        ),
+      ).toBe(0);
+      expect(
+        store.callsWith(
+          "findDirectTuple",
+          "doc",
+          "1",
+          "owner",
+          "user",
+          "alice",
+        ),
+      ).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two independent reductions in the store traffic a check issues, both
aligning tsfga with how upstream OpenFGA does it.

- **Share one request scope across `listObjects`.** Each candidate used
  to build its own relation-config cache and node memo, so N documents
  behind one folder re-read every config N times and re-resolved the
  shared subtree N times. A `CheckScope` now spans the whole call. The
  serial candidate loop also becomes a pool bounded by `maxBreadth` —
  the same knob upstream sizes its ListObjects pool with
  (`1 + resolveNodeBreadthLimit`).
- **Skip tuple reads the relation config rules out.** Every node issued
  a direct probe, a wildcard probe and a userset scan regardless of what
  the relation admitted. Each is now gated on the config, mirroring
  `shouldCheckDirectTuple` / `shouldCheckPublicAssignable` / a non-empty
  `DirectlyRelatedUsersets`.

Measured store reads:

| Workload | before | after |
|---|---:|---:|
| 1000-branch union (miss) | 3005 | 1004 |
| 100-way tuple-to-userset (miss) | 306 | 104 |
| `listObjects`, 200 candidates sharing a subtree | 2361 | 436 |

## Behavior changes

- **A tuple the model does not admit no longer grants.** One written
  straight to the database past `addTuple`, or orphaned by a relation
  that has since narrowed its type list, is now ignored. Relation
  configs are load-bearing for the read path rather than advisory.
  Fail-closed, and it is what OpenFGA does — it rejects such a tuple at
  write time. The read gate is literally the write path's predicate,
  imported rather than restated, so a writable tuple is always findable.
- **`listObjects` results are in candidate order** and the error it
  raises is the first failing candidate *in candidate order*, not the
  first to fail in time. Both were arbitrary once candidates run
  concurrently; both are now specified and tested. Ordering is a tsfga
  determinism choice, not parity — upstream streams in completion order.
- Ordering the config read before the tuple reads gives up the single
  overlapping read wave, also unreleased. It costs one round-trip per
  relation per request, not per node, because configs are cached.

A known gap is documented rather than closed: upstream issues *zero*
reads for a purely computed relation, while tsfga encodes
"purely computed" as the same `directlyAssignableTypes: null` that means
"unrestricted". Distinguishing them would change write semantics too.

## Test plan

- [x] `bun run biome:check`, `bun run tsc`
- [x] `@tsfga/core` 187 pass on Bun, Node and Deno (30 new tests:
      `list-objects.test.ts`, `read-gating.test.ts`)
- [x] `@tsfga/kysely` 49 pass
- [x] `@tsfga/conformance` 362 pass, unedited — every case still agrees
      with a live OpenFGA
- [x] CI green on all jobs
- [x] Gates mutation-checked: dropping the shared scope, the
      lowest-index error rule, the launch cut-off, or widening the read
      gate each fails a dedicated test

Five existing tests changed. Each asserted behavior these commits
deliberately alter — the reversed config/read ordering, wildcard probes
that no longer fire, and a memoization proxy the gate removes. The
commit bodies itemize them.

No conformance case covers the ignored-tuple change because none can be
constructed: OpenFGA rejects `user:*`, `team:eng` and `team:eng#member`
writes against `define viewer: [user]`, so a tuple only the looser
engine holds cannot exist on both sides. Core tests write straight to a
mock store instead.