### PR TITLE
Read a check node's tuples in one store call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,21 +239,15 @@ database backend. All methods return `Promise`.
 export interface TupleStore {
   // === Read ===
 
-  /** Check if a direct tuple exists (no subject_relation) */
-  findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null>;
-
-  /** Find tuples where subject_relation IS NOT NULL (userset expansion) */
-  findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]>;
+  /**
+   * All three per-node check reads in one call: the subject's
+   * direct tuple, the `subjectType:*` wildcard tuple, and the
+   * usersets on the relation. A part the query excludes must be
+   * reported absent even if rows for it exist — the exclusions
+   * come from the relation config, so such a row is one the model
+   * does not admit.
+   */
+  findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples>;
 
   /** Find tuples by object + relation (for tuple-to-userset tupleset lookup) */
   findTuplesByRelation(
@@ -329,15 +323,18 @@ export async function check(
     throw new DepthExceededError(...);
   }
 
+  // Steps 1 and 2 read together. `findCheckTuples` returns the
+  // direct tuple, the wildcard tuple and the userset rows in one
+  // call, and takes the relation config's gates so a part the
+  // model cannot admit is never asked for.
+  const { direct: directTuple, usersets: usersetTuples } =
+    await store.findCheckTuples({ ...node, ...gatesFrom(config) });
+
   // Step 1: Direct tuple check
-  // Look for exact match: (objectType, objectId, relation, subjectType, subjectId)
-  // where subject_relation IS NULL.
+  // Exact match on (objectType, objectId, relation, subjectType,
+  // subjectId) where subject_relation IS NULL.
   // If the tuple has a conditionName, evaluate the CEL condition.
   // Return true only if no condition or condition evaluates to true.
-  const directTuple = await store.findDirectTuple(
-    request.objectType, request.objectId, request.relation,
-    request.subjectType, request.subjectId,
-  );
   if (directTuple) {
     if (await evaluateTupleCondition(store, directTuple, request.context)) {
       return true;
@@ -345,14 +342,11 @@ export async function check(
   }
 
   // Step 2: Userset expansion
-  // Find tuples where subject_relation IS NOT NULL.
+  // The rows with subject_relation IS NOT NULL, read above.
   // e.g., (channel:proj, writer, workspace:sandcastle#member)
   // For each, recursively check if the user has the subject_relation
   // on the referenced subject object.
   // If the userset tuple has a conditionName, evaluate before recursing.
-  const usersetTuples = await store.findUsersetTuples(
-    request.objectType, request.objectId, request.relation,
-  );
   for (const userset of usersetTuples) {
     if (!await evaluateTupleCondition(store, userset, request.context)) {
       continue;

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,70 @@ releases may contain breaking changes).
 
 ### Breaking changes
 
+- **`TupleStore.findDirectTuple` and `TupleStore.findUsersetTuples`
+  are replaced by `findCheckTuples`.** A check node wanted all
+  three reads — the subject's direct tuple, the `type:*` wildcard
+  tuple, the userset rows — and issued three calls for them. It
+  now issues one, taking a `CheckTuplesQuery` and returning a
+  `CheckTuples`; both types are exported. Custom `TupleStore`
+  implementations must be updated: the two old methods are gone,
+  with no fallback shim.
+
+  The query carries which parts the caller wants, so the relation
+  config gating below still applies. Those `include*` flags let a
+  store narrow its query, but they are not a trust boundary: the
+  check algorithm re-clamps every reply against the query it
+  sent, so a store that ignores a flag or files a row under the
+  wrong slot loses that row rather than granting access the model
+  forbids. A node whose config rules out all three parts skips
+  the store altogether.
+
+  This is a latency change, not a work change: the number of rows
+  read is the same, and the store-call count barely moves,
+  because the type-restriction gating below had already cut most
+  nodes to a single admitted read. What moves is round-trips and
+  connection-pool pressure. A node used to issue up to three
+  concurrent reads, so at the default `maxBreadth` of 10 a single
+  wide node could demand up to 30 connections at once; it now
+  demands 10. Measured against PostgreSQL on a 10-connection
+  pool, relations that admit more than one part (`[user,
+  group#member]`, the common nested-group shape) resolve
+  1.8x–3.0x faster; relations that admit exactly one part emit
+  identical SQL and are unchanged. On a single-connection handle
+  every shape improves, 1.1x–2.3x.
+
+  Porting a custom store is mechanical. The minimal version keeps
+  whatever queries you already had and drops the flags:
+
+  ```ts
+  async findCheckTuples(query) {
+    const onNode = [query.objectType, query.objectId, query.relation];
+    return {
+      direct: query.includeDirect
+        ? await this.oldFindDirectTuple(
+            ...onNode, query.subjectType, query.subjectId)
+        : null,
+      wildcard: query.includeWildcard
+        ? await this.oldFindDirectTuple(
+            ...onNode, query.subjectType, "*")
+        : null,
+      usersets: query.includeUsersets
+        ? await this.oldFindUsersetTuples(...onNode)
+        : [],
+    };
+  }
+  ```
+
+  That is correct but keeps three round-trips. The point of the
+  change is to serve the parts in one query where the backend can
+  — see `@tsfga/kysely` for a SQL implementation.
+
+  `ContextualTupleStore`'s overlay is unchanged and still
+  deliberately asymmetric: a contextual tuple *replaces* the
+  stored direct or wildcard tuple (a probe returns one row, so an
+  override has to win outright) but is *concatenated* with the
+  stored userset rows.
+
 - **A cycle in the resolution path no longer throws.** Revisiting
   a node used to raise `DepthExceededError`, the same error as
   depth exhaustion. It now resolves `false`, and `check()` returns

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -193,18 +193,27 @@ candidate after a failure is started.
 
 ## Relation configs gate the reads
 
-Each node of a check can issue three tuple reads: a direct probe
-for the subject, a probe for a `type:*` wildcard, and a scan for
-userset rows. A read is skipped when the relation config says
+Each node of a check wants up to three things about its object and
+relation: a direct tuple for the subject, a `type:*` wildcard
+tuple, and the userset rows. They are asked for **in one store
+call**, `findCheckTuples`, because they share an object, a
+relation and a plan — three separate queries cost three
+round-trips and, on a single-connection handle, three serialized
+ones.
+
+A part is left out of the query when the relation config says
 nothing it could find would be valid:
 
-| Read | Skipped when |
+| Part | Left out when |
 |---|---|
 | direct probe | `directlyAssignableTypes` omits the subject type |
 | wildcard probe | `directlyAssignableTypes` omits `subjectType:*` |
 | userset scan | `allowsUsersetSubjects` is `false` |
 
-A read is skipped only on a *positive* exclusion. A relation with
+With all three ruled out there is nothing to ask, and the node
+skips the store entirely — it still resolves through its rewrites.
+
+A part is left out only on a *positive* exclusion. A relation with
 no config at all, or with `directlyAssignableTypes: null` — which
 means "not narrowed", not "purely computed" — still reads
 everything. The gate is the same predicate `addTuple` applies, so
@@ -246,6 +255,28 @@ contextual tuples throw `RelationConfigNotFoundError`,
 The `TupleStore` interface is the extension point for custom
 database adapters. The core check algorithm depends only on
 this interface — it has no database dependencies.
+
+Its read surface is deliberately shaped around what a check
+actually asks for, not around individual predicates. The one to
+understand when writing an adapter is `findCheckTuples`: it takes
+a `CheckTuplesQuery` (the node, plus which of the three parts are
+wanted) and returns a `CheckTuples` (`direct`, `wildcard`,
+`usersets`). Both types are exported. Serving it as one query is
+the single largest thing an adapter can do for check latency; an
+implementation may run three instead, and simply gives that up.
+
+The `include*` flags exist so a store can **narrow** its query —
+that is where the saving is. They are a hint, not a trust
+boundary: `check` re-clamps every reply against the query it
+sent, so returning a part that was not asked for, or filing a row
+under the wrong slot, loses that row. An adapter bug cannot widen
+what the model admits, only lose grants it should have found.
+
+Slots are exact. `direct` is the tuple for this subject with no
+subject relation, `wildcard` the one for `subjectType:*` likewise,
+and every row in `usersets` has a subject relation. A minimal
+correct implementation may ignore the flags entirely and return
+all three parts; it just gives up the saving.
 
 See
 [`src/store-interface.ts`](src/store-interface.ts)

--- a/packages/core/src/caching-store.ts
+++ b/packages/core/src/caching-store.ts
@@ -1,6 +1,8 @@
 import type { TupleStore } from "./store-interface.ts";
 import type {
   AddTupleRequest,
+  CheckTuples,
+  CheckTuplesQuery,
   ConditionDefinition,
   RelationConfig,
   RemoveTupleRequest,
@@ -89,28 +91,8 @@ export class CachingTupleStore implements TupleStore {
     });
   }
 
-  findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
-    return this.inner.findDirectTuple(
-      objectType,
-      objectId,
-      relation,
-      subjectType,
-      subjectId,
-    );
-  }
-
-  findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]> {
-    return this.inner.findUsersetTuples(objectType, objectId, relation);
+  findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    return this.inner.findCheckTuples(query);
   }
 
   findTuplesByRelation(

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -12,17 +12,11 @@ import {
 import type {
   CheckOptions,
   CheckRequest,
+  CheckTuples,
+  CheckTuplesQuery,
   RelationConfig,
   Tuple,
 } from "./types.ts";
-
-/**
- * Results of the per-node tuple batch: direct, wildcard, userset.
- * A slot the relation config rules out is filled with the same
- * empty value the store would have returned, so consumers never
- * distinguish "not read" from "read, found nothing".
- */
-type NodeReads = readonly [Tuple | null, Tuple | null, readonly Tuple[]];
 
 /**
  * Internal result of resolving one node.
@@ -522,16 +516,17 @@ async function resolveNode(
 }
 
 /**
- * Issue the per-node tuple reads (direct probe, wildcard probe,
- * userset scan) as one batch, skipping any the relation config
- * says cannot match.
+ * Ask the store for the node's tuples — direct probe, wildcard
+ * probe, userset scan — in one request, excluding any part the
+ * relation config says cannot match.
  *
- * A read is skipped only when the config *positively excludes* it.
- * No config, or a config that declines to narrow the relation
- * (`directlyAssignableTypes: null`), reads everything. The gate is
- * the same predicate the write path applies, imported from
- * `tuple-validation.ts` rather than restated, so a tuple that can
- * be written is always a tuple that can be found.
+ * A part is excluded only when the config *positively rules it
+ * out*. No config, or a config that declines to narrow the
+ * relation (`directlyAssignableTypes: null`), asks for
+ * everything. The gate is the same predicate the write path
+ * applies, imported from `tuple-validation.ts` rather than
+ * restated, so a tuple that can be written is always a tuple that
+ * can be found.
  *
  * This mirrors upstream, which builds `checkDirect`'s three
  * handlers behind `shouldCheckDirectTuple`,
@@ -541,46 +536,130 @@ async function resolveNode(
  * purely computed relation issues no reads at all there, whereas
  * tsfga encodes "purely computed" as the same `null` that means
  * "unrestricted", so it cannot tell the two apart.
+ *
+ * The gates are sent to the store so it can narrow its query, and
+ * re-applied to its reply by `clampToQuery` so that narrowing
+ * stays an optimization rather than a correctness dependency.
  */
-function readNodeTuples(
+async function readNodeTuples(
   store: TupleStore,
   request: CheckRequest,
   config: RelationConfig | null,
-): Promise<NodeReads> {
+): Promise<CheckTuples> {
   const subjectRef = directSubjectRef(request.subjectType, request.subjectId);
   const wildcardRef = `${request.subjectType}:*`;
 
-  return Promise.all([
-    admitsDirectSubject(config, subjectRef)
-      ? store.findDirectTuple(
-          request.objectType,
-          request.objectId,
-          request.relation,
-          request.subjectType,
-          request.subjectId,
-        )
-      : null,
-    admitsDirectSubject(config, wildcardRef)
-      ? store.findDirectTuple(
-          request.objectType,
-          request.objectId,
-          request.relation,
-          request.subjectType,
-          "*",
-        )
-      : null,
-    admitsUsersetSubjects(config)
-      ? store.findUsersetTuples(
-          request.objectType,
-          request.objectId,
-          request.relation,
-        )
-      : NO_TUPLES,
-  ]);
+  const includeDirect = admitsDirectSubject(config, subjectRef);
+  // Checking the wildcard subject itself makes the two probes the
+  // same query, and `directSubjectRef` makes their gates agree
+  // too. Ask once: `checkBase` reads the slots identically, so
+  // folding it into `direct` loses nothing and saves a duplicate
+  // condition evaluation.
+  const includeWildcard =
+    request.subjectId === "*"
+      ? false
+      : admitsDirectSubject(config, wildcardRef);
+  const includeUsersets = admitsUsersetSubjects(config);
+
+  // A relation that admits none of the three — say one that is
+  // purely an intersection of rewrites — has nothing to ask for.
+  // Skip the round-trip rather than send a query that cannot
+  // match; the node still resolves through its rewrites.
+  if (!includeDirect && !includeWildcard && !includeUsersets) {
+    return NO_TUPLES;
+  }
+
+  const query: CheckTuplesQuery = {
+    objectType: request.objectType,
+    objectId: request.objectId,
+    relation: request.relation,
+    subjectType: request.subjectType,
+    subjectId: request.subjectId,
+    includeDirect,
+    includeWildcard,
+    includeUsersets,
+  };
+  return clampToQuery(await store.findCheckTuples(query), query);
 }
 
-/** Stand-in for a userset scan the config rules out. Never mutated. */
-const NO_TUPLES: readonly Tuple[] = [];
+/**
+ * Stand-in for a node whose reads the config rules out entirely.
+ * Never mutated, so aliasing it across nodes is safe.
+ */
+const NO_TUPLES: CheckTuples = { direct: null, wildcard: null, usersets: [] };
+
+/**
+ * Discard anything in a store's reply that the query did not ask
+ * for, or that is filed under the wrong slot.
+ *
+ * Before the three reads were merged, the relation config's type
+ * restrictions were enforced by *not making the call* — a tuple
+ * the model forbids was unreachable because no code path looked
+ * for it. Merging moved that enforcement into a flag on a request,
+ * and a flag is only as good as the store honouring it. That
+ * would make every adapter, including third-party ones, part of
+ * the security boundary: a store that ignored `includeUsersets`
+ * would hand back a userset row on a relation that forbids
+ * usersets, and `checkBase` would expand it and grant. Silently.
+ *
+ * So the flags stay a hint and the guarantee moves back here.
+ * Clamping is cheap, it is one place, and it makes the failure
+ * direction closed: a store that over-returns loses rows rather
+ * than smuggling them past the model. Upstream reaches the same
+ * conclusion by a different route, filtering each handler's rows
+ * through `validation.FilterInvalidTuples` after having already
+ * chosen the handlers by type (`internal/graph/check.go`).
+ *
+ * A misfiled row is dropped rather than raised. There is no safe
+ * reading of it, and a check is the wrong place to discover an
+ * adapter bug — denying is the conservative answer, and the
+ * adapter's own tests are where this should have been caught.
+ */
+function clampToQuery(
+  reply: CheckTuples,
+  query: CheckTuplesQuery,
+): CheckTuples {
+  const onNode = (tuple: Tuple): boolean =>
+    tuple.objectType === query.objectType &&
+    tuple.objectId === query.objectId &&
+    tuple.relation === query.relation;
+
+  // A probe answers for one subject with no subject relation; the
+  // wildcard slot answers for `*` and nothing else.
+  const isProbe = (tuple: Tuple | null, subjectId: string): boolean =>
+    tuple !== null &&
+    onNode(tuple) &&
+    tuple.subjectType === query.subjectType &&
+    tuple.subjectId === subjectId &&
+    tuple.subjectRelation === null;
+
+  // Usersets carry their own subject type — `team:eng#member` on a
+  // `user` check — so only the node and the subject relation are
+  // checkable here.
+  const isUserset = (tuple: Tuple): boolean =>
+    onNode(tuple) && tuple.subjectRelation !== null;
+
+  let usersets: readonly Tuple[] = NO_TUPLES.usersets;
+  if (query.includeUsersets) {
+    // Reuse the reply's array when it is already clean, which is
+    // every well-behaved store on every node.
+    usersets = reply.usersets.every(isUserset)
+      ? reply.usersets
+      : reply.usersets.filter(isUserset);
+  }
+
+  return {
+    direct:
+      query.includeDirect && isProbe(reply.direct, query.subjectId)
+        ? reply.direct
+        : null,
+    wildcard:
+      query.includeWildcard && isProbe(reply.wildcard, "*")
+        ? reply.wildcard
+        : null,
+    usersets,
+  };
+}
 
 /**
  * A tuple's condition as a union branch. Condition evaluation can
@@ -604,14 +683,18 @@ async function checkBase(
   store: TupleStore,
   request: CheckRequest,
   config: RelationConfig | null,
-  reads: Promise<NodeReads>,
+  reads: Promise<CheckTuples>,
   maxDepth: number,
   maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
   memo: NodeMemo,
 ): Promise<CheckResult> {
-  const [directTuple, wildcardTuple, usersetTuples] = await reads;
+  const {
+    direct: directTuple,
+    wildcard: wildcardTuple,
+    usersets: usersetTuples,
+  } = await reads;
 
   // Steps 1/1b: an unconditioned direct or wildcard hit answers
   // immediately, before any sub-check is launched
@@ -757,7 +840,7 @@ async function checkIntersection(
   store: TupleStore,
   request: CheckRequest,
   config: RelationConfig,
-  reads: Promise<NodeReads>,
+  reads: Promise<CheckTuples>,
   maxDepth: number,
   maxBreadth: number,
   depth: number,

--- a/packages/core/src/contextual-store.ts
+++ b/packages/core/src/contextual-store.ts
@@ -1,6 +1,8 @@
 import type { TupleStore } from "./store-interface.ts";
 import type {
   AddTupleRequest,
+  CheckTuples,
+  CheckTuplesQuery,
   ConditionDefinition,
   RelationConfig,
   RemoveTupleRequest,
@@ -31,52 +33,68 @@ export class ContextualTupleStore implements TupleStore {
     }));
   }
 
-  async findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
-    // Check contextual tuples first
-    const contextual = this.contextualTuples.find(
-      (t) =>
-        t.objectType === objectType &&
-        t.objectId === objectId &&
-        t.relation === relation &&
-        t.subjectType === subjectType &&
-        t.subjectId === subjectId &&
-        t.subjectRelation === null,
-    );
-    if (contextual) return contextual;
+  /**
+   * The overlay is deliberately asymmetric, and merging the three
+   * reads into one call must not quietly even it out.
+   *
+   * A direct or wildcard probe returns *one* tuple, so a
+   * contextual tuple on that exact key **replaces** the stored one
+   * — it is not unioned with it. That is what lets a caller
+   * override a conditioned stored tuple with an unconditioned
+   * contextual one. The userset scan returns a *set*, so there
+   * contextual rows are **concatenated** with the stored ones.
+   *
+   * A part the overlay already answers is dropped from the inner
+   * query, so a replaced probe still costs the store nothing.
+   */
+  async findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    const direct = query.includeDirect
+      ? this.findContextualDirect(query, query.subjectId)
+      : null;
+    const wildcard = query.includeWildcard
+      ? this.findContextualDirect(query, "*")
+      : null;
 
-    return this.inner.findDirectTuple(
-      objectType,
-      objectId,
-      relation,
-      subjectType,
-      subjectId,
+    const stored = await this.inner.findCheckTuples({
+      ...query,
+      includeDirect: query.includeDirect && direct === null,
+      includeWildcard: query.includeWildcard && wildcard === null,
+    });
+
+    return {
+      direct: direct ?? stored.direct,
+      wildcard: wildcard ?? stored.wildcard,
+      usersets: query.includeUsersets
+        ? [...this.findContextualUsersets(query), ...stored.usersets]
+        : stored.usersets,
+    };
+  }
+
+  private findContextualDirect(
+    query: CheckTuplesQuery,
+    subjectId: string,
+  ): Tuple | null {
+    return (
+      this.contextualTuples.find(
+        (t) =>
+          t.objectType === query.objectType &&
+          t.objectId === query.objectId &&
+          t.relation === query.relation &&
+          t.subjectType === query.subjectType &&
+          t.subjectId === subjectId &&
+          t.subjectRelation === null,
+      ) ?? null
     );
   }
 
-  async findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]> {
-    const contextual = this.contextualTuples.filter(
+  private findContextualUsersets(query: CheckTuplesQuery): Tuple[] {
+    return this.contextualTuples.filter(
       (t) =>
-        t.objectType === objectType &&
-        t.objectId === objectId &&
-        t.relation === relation &&
+        t.objectType === query.objectType &&
+        t.objectId === query.objectId &&
+        t.relation === query.relation &&
         t.subjectRelation !== null,
     );
-    const stored = await this.inner.findUsersetTuples(
-      objectType,
-      objectId,
-      relation,
-    );
-    return [...contextual, ...stored];
   }
 
   async findTuplesByRelation(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,6 +158,8 @@ export type {
   AddTupleRequest,
   CheckOptions,
   CheckRequest,
+  CheckTuples,
+  CheckTuplesQuery,
   ConditionDefinition,
   ConditionParameterType,
   IntersectionOperand,

--- a/packages/core/src/store-interface.ts
+++ b/packages/core/src/store-interface.ts
@@ -1,5 +1,7 @@
 import type {
   AddTupleRequest,
+  CheckTuples,
+  CheckTuplesQuery,
   ConditionDefinition,
   RelationConfig,
   RemoveTupleRequest,
@@ -9,21 +11,31 @@ import type {
 export interface TupleStore {
   // === Read ===
 
-  /** Check if a direct tuple exists (no subject_relation) */
-  findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null>;
-
-  /** Find tuples where subject_relation IS NOT NULL (userset expansion) */
-  findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]>;
+  /**
+   * Read the tuples one check node needs: the subject's direct
+   * tuple, the `subjectType:*` wildcard tuple, and the usersets
+   * assigned to the relation.
+   *
+   * These three are asked for together because a check issues
+   * them together, at every node it visits — serving them in one
+   * round-trip is the single largest thing an adapter can do for
+   * check latency. An implementation is free to run three queries
+   * instead; it just gives that up.
+   *
+   * The `include*` flags are there so a store can **narrow** its
+   * query — that is where the saving is. They are not a contract
+   * you can breach dangerously: the check algorithm re-clamps
+   * every reply against the query it sent, so returning a part
+   * that was not asked for, or filing a row under the wrong slot,
+   * loses that row. It cannot widen what the model admits.
+   *
+   * Slots are exact. `direct` is the tuple for this subject with
+   * no subject relation; `wildcard` is the one for
+   * `subjectType:*`, likewise with no subject relation; every row
+   * in `usersets` has a subject relation. Anything else is
+   * discarded.
+   */
+  findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples>;
 
   /** Find tuples by object + relation (for tuple-to-userset tupleset lookup) */
   findTuplesByRelation(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,59 @@ export interface Tuple {
   conditionContext: Record<string, unknown> | null;
 }
 
+/**
+ * The tuple reads one node of a check needs, as one request.
+ *
+ * A node can want up to three things about `objectType:objectId`
+ * and `relation`: whether the subject holds it directly, whether
+ * a `subjectType:*` wildcard grants it publicly, and which
+ * usersets are assigned to it. They are asked for together so a
+ * store can serve them in one round-trip.
+ *
+ * The three `include*` flags say which parts the caller wants.
+ * They reflect the relation config: a part the model cannot admit
+ * is not requested at all.
+ *
+ * They are a **narrowing hint, not a trust boundary**. A store
+ * may use them to skip work — that is the point of sending them —
+ * but it is never relied on to. The check algorithm re-clamps
+ * every reply against the query it sent, so a store that ignores
+ * a flag, or files a row under the wrong slot, loses that row
+ * rather than smuggling it past the model's type restrictions.
+ * Narrowing is the store's business; widening is impossible.
+ */
+export interface CheckTuplesQuery {
+  objectType: string;
+  objectId: string;
+  relation: string;
+  subjectType: string;
+  subjectId: string;
+  /** Direct tuple for exactly this subject, no subject relation. */
+  includeDirect: boolean;
+  /** Direct tuple for `subjectType:*`, no subject relation. */
+  includeWildcard: boolean;
+  /** Every tuple on this relation with a subject relation. */
+  includeUsersets: boolean;
+}
+
+/**
+ * What a `CheckTuplesQuery` found.
+ *
+ * A part the query excluded reads back as `null` / `[]` — the same
+ * value it would have on a miss. That is deliberate: the check
+ * algorithm treats "the model forbids it" and "nothing is stored"
+ * identically, so nothing downstream has to tell them apart.
+ *
+ * `usersets` is `readonly` because the check algorithm aliases a
+ * shared empty array for the excluded case rather than allocating
+ * one per node.
+ */
+export interface CheckTuples {
+  direct: Tuple | null;
+  wildcard: Tuple | null;
+  usersets: readonly Tuple[];
+}
+
 /** An operand in an intersection expression */
 export type IntersectionOperand =
   | { type: "direct" }

--- a/packages/core/tests/caching-store.test.ts
+++ b/packages/core/tests/caching-store.test.ts
@@ -235,10 +235,20 @@ describe("CachingTupleStore", () => {
   });
 
   test("tuple reads pass through uncached", async () => {
-    await caching.findDirectTuple("doc", "d1", "viewer", "user", "alice");
-    await caching.findDirectTuple("doc", "d1", "viewer", "user", "alice");
+    const query = {
+      objectType: "doc",
+      objectId: "d1",
+      relation: "viewer",
+      subjectType: "user",
+      subjectId: "alice",
+      includeDirect: true,
+      includeWildcard: true,
+      includeUsersets: true,
+    };
+    await caching.findCheckTuples(query);
+    await caching.findCheckTuples(query);
 
-    expect(store.counts.findDirectTuple).toBe(2);
+    expect(store.counts.findCheckTuples).toBe(2);
   });
 });
 

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../src/check.ts";
 import { ConditionNotFoundError, TsfgaError } from "../src/errors.ts";
 import type {
+  CheckTuples,
+  CheckTuplesQuery,
   ConditionDefinition,
   RelationConfig,
   Tuple,
@@ -52,7 +54,7 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
- * Records which relations are probed (direct reads and config
+ * Records which relations are probed (node tuple reads and config
  * reads), so tests can assert that queued branches beyond the
  * breadth limit never start once the node has settled.
  */
@@ -60,21 +62,9 @@ class RecordingStore extends MockTupleStore {
   probedRelations: string[] = [];
   configRelations: string[] = [];
 
-  override findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
-    this.probedRelations.push(relation);
-    return super.findDirectTuple(
-      objectType,
-      objectId,
-      relation,
-      subjectType,
-      subjectId,
-    );
+  override findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    this.probedRelations.push(query.relation);
+    return super.findCheckTuples(query);
   }
 
   override findRelationConfig(

--- a/packages/core/tests/check-concurrency.test.ts
+++ b/packages/core/tests/check-concurrency.test.ts
@@ -4,10 +4,16 @@ import {
   ConditionNotFoundError,
   RelationConfigNotFoundError,
 } from "../src/errors.ts";
-import type { RelationConfig, Tuple } from "../src/types.ts";
+import type {
+  CheckTuples,
+  CheckTuplesQuery,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
 import {
   ConfigErrorStore,
   StoreReadFailure,
+  TupleReadErrorStore,
 } from "./helpers/erroring-store.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
@@ -69,32 +75,8 @@ class GatedStore extends MockTupleStore {
     return this.gate(() => super.findRelationConfig(objectType, relation));
   }
 
-  override findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
-    return this.gate(() =>
-      super.findDirectTuple(
-        objectType,
-        objectId,
-        relation,
-        subjectType,
-        subjectId,
-      ),
-    );
-  }
-
-  override findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]> {
-    return this.gate(() =>
-      super.findUsersetTuples(objectType, objectId, relation),
-    );
+  override findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    return this.gate(() => super.findCheckTuples(query));
   }
 }
 
@@ -134,7 +116,7 @@ class SlowConfigStore extends MockTupleStore {
   }
 }
 
-describe("node read waves", () => {
+describe("node reads", () => {
   /** A relation that admits all three reads, so none is gated out. */
   function wideOpenConfig(relation: string): RelationConfig {
     return makeConfig({
@@ -145,11 +127,11 @@ describe("node read waves", () => {
     });
   }
 
-  test("the admitted tuple reads are issued as one wave", async () => {
-    // The config read no longer overlaps them: the reads are
-    // gated on what the config admits, so it has to land first.
-    // What is still asserted is that the reads it does admit go
-    // out together rather than one at a time.
+  test("a node asks the store once, not three times", async () => {
+    // A relation that admits all three reads. They used to be
+    // three concurrent store calls — one wave, but three
+    // round-trips, which on a single-connection handle serialize.
+    // They are now one call, so the gate never sees two at once.
     const store = new GatedStore();
     store.relationConfigs.push(wideOpenConfig("viewer"));
 
@@ -162,7 +144,8 @@ describe("node read waves", () => {
     });
 
     expect(result).toBe(false);
-    expect(store.highWater).toBe(3);
+    expect(store.highWater).toBe(1);
+    expect(store.counts.findCheckTuples).toBe(1);
   });
 
   test("a second node of the same relation pays no config read", async () => {
@@ -212,9 +195,11 @@ describe("node read waves", () => {
     expect(store.callsWith("findRelationConfig", "doc", "inner")).toBe(2);
   });
 
-  test("skipped reads do not stall the wave", async () => {
-    // A gated-out slot is filled synchronously. If it were left
-    // as a pending promise the batch would never settle.
+  test("the gated-out parts are not asked for", async () => {
+    // One call either way, so the saving is no longer in the call
+    // count — it is in what the call asks for. A part the config
+    // rules out must be absent from the query, or the store has no
+    // way to narrow the scan.
     const store = new GatedStore();
     store.relationConfigs.push(
       makeConfig({
@@ -233,9 +218,82 @@ describe("node read waves", () => {
         subjectId: "alice",
       }),
     ).toBe(false);
-    // Only the subject's direct probe survives the gate: no
-    // `user:*` in the type list, and no userset subjects.
-    expect(store.highWater).toBe(1);
+    // No `user:*` in the type list, and no userset subjects.
+    expect(store.queriesFor("doc", "1", "viewer")).toEqual([
+      {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+        includeDirect: true,
+        includeWildcard: false,
+        includeUsersets: false,
+      },
+    ]);
+  });
+
+  test("a node the config closes entirely reads nothing", async () => {
+    // Every part gated out leaves no query worth sending. The node
+    // still resolves — through its rewrite, which reads for itself.
+    const store = new GatedStore();
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: [],
+        computedUserset: "owner",
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "owner",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "owner",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+
+    expect(
+      await check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).toBe(true);
+    expect(store.queriesFor("doc", "1", "viewer")).toEqual([]);
+    expect(store.counts.findCheckTuples).toBe(1);
+  });
+
+  test("a tuple-read error fails the node", async () => {
+    // The counterpart to the config-read failure below: the read
+    // that happens after the config resolved.
+    const store = new TupleReadErrorStore(["viewer"]);
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "viewer",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+
+    await expect(
+      check(store, {
+        objectType: "doc",
+        objectId: "1",
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    ).rejects.toBeInstanceOf(StoreReadFailure);
   });
 
   test("a config-read error fails the node", async () => {
@@ -311,11 +369,9 @@ describe("node read waves", () => {
     });
 
     expect(result).toBe(true);
-    // Only the root node's subject probe; the wildcard probe is
-    // gated out (no `user:*` in the type list) and the 3 userset
-    // branches would each have added one more.
-    expect(store.counts.findDirectTuple).toBe(1);
-    expect(store.counts.findUsersetTuples).toBe(1);
+    // Only the root node's read; each of the 3 userset branches
+    // would have added one more.
+    expect(store.counts.findCheckTuples).toBe(1);
   });
 
   test("sibling grant wins over a direct-condition error", async () => {
@@ -461,10 +517,10 @@ describe("node read waves", () => {
     });
 
     expect(result).toBe(true);
-    // One root probe plus one per launched userset branch. Was 8
-    // before the read gating: every node also probed for a
-    // `user:*` tuple that neither type list admits.
-    expect(store.counts.findDirectTuple).toBe(4);
+    // The root node plus one per launched userset branch. Was 4
+    // direct probes and 4 userset scans when a node read three
+    // times; the branches still all launch, they just read once.
+    expect(store.counts.findCheckTuples).toBe(4);
   });
 
   test("surfaced error follows completion order across branches", async () => {

--- a/packages/core/tests/check-memo.test.ts
+++ b/packages/core/tests/check-memo.test.ts
@@ -34,15 +34,11 @@ function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
 }
 
 /**
- * These tests count `findDirectTuple` for the subject as the
- * "this node was resolved" signal. It used to be
- * `findUsersetTuples`, which read better, but the read gating
- * skips the userset scan on any relation that forbids userset
- * subjects — which is most of the fixtures here — so that call no
- * longer happens once per node visit. The subject's direct probe
- * does, on every relation these fixtures declare. The extra
- * subject arguments matter: a node also probes for a wildcard, and
- * `callsWith` on the object alone would count both.
+ * These tests count `findCheckTuples` as the "this node was
+ * resolved" signal. A node makes exactly one of those calls, for
+ * whichever of the three reads its relation config admits, so the
+ * node's identity alone is enough to count visits — no subject
+ * arguments needed to disambiguate.
  *
  * Every test here runs at `maxBreadth: 1` unless it says otherwise.
  * The memo publishes settled results only — never in-flight
@@ -103,16 +99,7 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "shared",
-          "user",
-          "alice",
-        ),
-      ).toBe(1);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "shared")).toBe(1);
     });
 
     test("a definitive true is served from the memo", async () => {
@@ -136,26 +123,8 @@ describe("request-scoped node memoization", () => {
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(true);
       // `left` grants and the union stops, so `shared` is read once
       // — by `left`, never by `right`.
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "shared",
-          "user",
-          "alice",
-        ),
-      ).toBe(1);
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "right",
-          "user",
-          "alice",
-        ),
-      ).toBe(0);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "shared")).toBe(1);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "right")).toBe(0);
     });
 
     test("without a shared node nothing is deduplicated", async () => {
@@ -181,12 +150,8 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
-      expect(
-        store.callsWith("findDirectTuple", "doc", "1", "l2", "user", "alice"),
-      ).toBe(1);
-      expect(
-        store.callsWith("findDirectTuple", "doc", "1", "r2", "user", "alice"),
-      ).toBe(1);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "l2")).toBe(1);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "r2")).toBe(1);
     });
   });
 
@@ -208,12 +173,8 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, SEQUENTIAL)).toBe(false);
-      expect(
-        store.callsWith("findDirectTuple", "doc", "1", "x", "user", "alice"),
-      ).toBe(2);
-      expect(
-        store.callsWith("findDirectTuple", "doc", "1", "p", "user", "alice"),
-      ).toBe(2);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "x")).toBe(2);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "p")).toBe(2);
     });
 
     test("a cross-branch cycle terminates instead of deadlocking", async () => {
@@ -322,16 +283,9 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
 
       expect(await check(store, viewerRequest, { maxBreadth: 1 })).toBe(false);
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "group",
-          "g",
-          "member",
-          "user",
-          "alice",
-        ),
-      ).toBe(1);
+      expect(store.callsWith("findCheckTuples", "group", "g", "member")).toBe(
+        1,
+      );
     });
 
     test("an entry recorded shallower is not reused deeper", async () => {
@@ -379,16 +333,7 @@ describe("request-scoped node memoization", () => {
       store.resetCounts();
       await check(store, viewerRequest, SEQUENTIAL);
 
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "shared",
-          "user",
-          "alice",
-        ),
-      ).toBe(1);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "shared")).toBe(1);
     });
   });
 });

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { check } from "../src/check.ts";
+import { ContextualTupleStore } from "../src/contextual-store.ts";
 import {
   DepthExceededError,
   InvalidSubjectTypeError,
@@ -858,6 +859,183 @@ describe("check algorithm", () => {
           ],
         }),
       ).toBe(false);
+    });
+
+    /**
+     * The overlay is asymmetric and has to stay that way. A probe
+     * returns one tuple, so a contextual tuple on that key
+     * *replaces* the stored one; the userset scan returns a set,
+     * so there the two are *concatenated*. Serving all three reads
+     * from one call makes it easy to even them out by accident,
+     * and either direction of that mistake is silent: replacing
+     * usersets drops stored grants, unioning a probe resurrects
+     * the stored tuple a caller was overriding.
+     */
+    describe("the overlay replaces probes and concatenates usersets", () => {
+      test("an unconditioned contextual tuple overrides a conditioned stored one", async () => {
+        // The stored tuple names a condition that does not exist,
+        // so evaluating it throws. Nothing should evaluate it: the
+        // contextual tuple takes its place entirely.
+        store.tuples.push(
+          makeTuple({
+            objectType: "doc",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+            conditionName: "missing",
+          }),
+        );
+
+        expect(
+          await check(store, {
+            objectType: "doc",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+            contextualTuples: [
+              {
+                objectType: "doc",
+                objectId: "1",
+                relation: "viewer",
+                subjectType: "user",
+                subjectId: "alice",
+              },
+            ],
+          }),
+        ).toBe(true);
+      });
+
+      test("a contextual wildcard overrides a conditioned stored one", async () => {
+        store.relationConfigs.push(
+          makeConfig({
+            objectType: "doc",
+            relation: "public",
+            directlyAssignableTypes: ["user", "user:*"],
+          }),
+        );
+        store.tuples.push(
+          makeTuple({
+            objectType: "doc",
+            objectId: "1",
+            relation: "public",
+            subjectType: "user",
+            subjectId: "*",
+            conditionName: "missing",
+          }),
+        );
+
+        expect(
+          await check(store, {
+            objectType: "doc",
+            objectId: "1",
+            relation: "public",
+            subjectType: "user",
+            subjectId: "alice",
+            contextualTuples: [
+              {
+                objectType: "doc",
+                objectId: "1",
+                relation: "public",
+                subjectType: "user",
+                subjectId: "*",
+              },
+            ],
+          }),
+        ).toBe(true);
+      });
+
+      test("a contextual userset does not hide a stored one", async () => {
+        // Only the *stored* userset leads to alice. If contextual
+        // rows replaced stored ones the way probes do, the grant
+        // would disappear.
+        store.relationConfigs.push(
+          makeConfig({
+            objectType: "team",
+            relation: "member",
+            directlyAssignableTypes: ["user"],
+          }),
+        );
+        store.tuples.push(
+          makeTuple({
+            objectType: "doc",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "team",
+            subjectId: "writers",
+            subjectRelation: "member",
+          }),
+          makeTuple({
+            objectType: "team",
+            objectId: "writers",
+            relation: "member",
+            subjectType: "user",
+            subjectId: "alice",
+          }),
+        );
+
+        expect(
+          await check(store, {
+            objectType: "doc",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+            contextualTuples: [
+              {
+                objectType: "doc",
+                objectId: "1",
+                relation: "viewer",
+                subjectType: "team",
+                subjectId: "readers",
+                subjectRelation: "member",
+              },
+            ],
+          }),
+        ).toBe(true);
+      });
+
+      test("a probe the overlay answers is dropped from the store query", async () => {
+        // Replacement means the stored row can never be used, so
+        // asking for it is wasted work. The userset part is still
+        // asked for, because there both halves are kept.
+        store.tuples.push(
+          makeTuple({
+            objectType: "doc",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+          }),
+        );
+        const overlay = new ContextualTupleStore(store, [
+          {
+            objectType: "doc",
+            objectId: "1",
+            relation: "viewer",
+            subjectType: "user",
+            subjectId: "alice",
+          },
+        ]);
+        store.resetCounts();
+
+        await overlay.findCheckTuples({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: "alice",
+          includeDirect: true,
+          includeWildcard: true,
+          includeUsersets: true,
+        });
+
+        const [inner] = store.queriesFor("doc", "1", "viewer");
+        expect(inner?.includeDirect).toBe(false);
+        expect(inner?.includeWildcard).toBe(true);
+        expect(inner?.includeUsersets).toBe(true);
+      });
     });
   });
 

--- a/packages/core/tests/helpers/erroring-store.ts
+++ b/packages/core/tests/helpers/erroring-store.ts
@@ -1,4 +1,8 @@
-import type { RelationConfig, Tuple } from "../../src/types.ts";
+import type {
+  CheckTuples,
+  CheckTuplesQuery,
+  RelationConfig,
+} from "../../src/types.ts";
 import { MockTupleStore } from "./mock-store.ts";
 
 /**
@@ -65,25 +69,24 @@ export class ConfigErrorStore extends MockTupleStore {
 }
 
 /**
- * Rejects the userset scan for the named relations instead of the
+ * Rejects the tuple read for the named relations instead of the
  * config read, so a branch can fail *after* its config resolved —
- * the other half of the node's single read wave.
+ * the node's other read, and the one a store is most likely to
+ * fail on in practice.
  */
-export class UsersetErrorStore extends MockTupleStore {
+export class TupleReadErrorStore extends MockTupleStore {
   constructor(private readonly erringRelations: readonly string[]) {
     super();
   }
 
-  override async findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]> {
-    if (this.erringRelations.includes(relation)) {
+  override async findCheckTuples(
+    query: CheckTuplesQuery,
+  ): Promise<CheckTuples> {
+    if (this.erringRelations.includes(query.relation)) {
       throw new StoreReadFailure(
-        `userset scan failed for ${objectType}.${relation}`,
+        `tuple read failed for ${query.objectType}.${query.relation}`,
       );
     }
-    return super.findUsersetTuples(objectType, objectId, relation);
+    return super.findCheckTuples(query);
   }
 }

--- a/packages/core/tests/helpers/mock-store.ts
+++ b/packages/core/tests/helpers/mock-store.ts
@@ -1,6 +1,8 @@
 import type { TupleStore } from "../../src/store-interface.ts";
 import type {
   AddTupleRequest,
+  CheckTuples,
+  CheckTuplesQuery,
   ConditionDefinition,
   RelationConfig,
   RemoveTupleRequest,
@@ -26,10 +28,32 @@ export class MockTupleStore implements TupleStore {
    */
   calls: Array<{ method: string; args: unknown[] }> = [];
 
+  /**
+   * Every `findCheckTuples` query, in call order. The call log
+   * above records a node's identity; this records which of the
+   * three reads the relation config let it ask for.
+   */
+  checkQueries: CheckTuplesQuery[] = [];
+
   /** Reset all call counts and the call log (data is untouched). */
   resetCounts(): void {
     this.counts = {};
     this.calls = [];
+    this.checkQueries = [];
+  }
+
+  /** Recorded check queries against one node, in call order. */
+  queriesFor(
+    objectType: string,
+    objectId: string,
+    relation: string,
+  ): CheckTuplesQuery[] {
+    return this.checkQueries.filter(
+      (q) =>
+        q.objectType === objectType &&
+        q.objectId === objectId &&
+        q.relation === relation,
+    );
   }
 
   /** Count calls to `method` whose arguments start with `args`. */
@@ -45,47 +69,42 @@ export class MockTupleStore implements TupleStore {
     this.calls.push({ method, args });
   }
 
-  async findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
+  async findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    // Tallied with the node's five identifying strings ahead of
+    // the query object, so `callsWith` can match a node by prefix
+    // the way it could when this was three separate methods.
     this.tally(
-      "findDirectTuple",
-      objectType,
-      objectId,
-      relation,
-      subjectType,
-      subjectId,
+      "findCheckTuples",
+      query.objectType,
+      query.objectId,
+      query.relation,
+      query.subjectType,
+      query.subjectId,
+      query,
     );
-    return (
-      this.tuples.find(
+    this.checkQueries.push(query);
+
+    const onRelation = this.tuples.filter(
+      (t) =>
+        t.objectType === query.objectType &&
+        t.objectId === query.objectId &&
+        t.relation === query.relation,
+    );
+    const findDirect = (subjectId: string) =>
+      onRelation.find(
         (t) =>
-          t.objectType === objectType &&
-          t.objectId === objectId &&
-          t.relation === relation &&
-          t.subjectType === subjectType &&
+          t.subjectType === query.subjectType &&
           t.subjectId === subjectId &&
           t.subjectRelation == null,
-      ) ?? null
-    );
-  }
+      ) ?? null;
 
-  async findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]> {
-    this.tally("findUsersetTuples", objectType, objectId, relation);
-    return this.tuples.filter(
-      (t) =>
-        t.objectType === objectType &&
-        t.objectId === objectId &&
-        t.relation === relation &&
-        t.subjectRelation != null,
-    );
+    return {
+      direct: query.includeDirect ? findDirect(query.subjectId) : null,
+      wildcard: query.includeWildcard ? findDirect("*") : null,
+      usersets: query.includeUsersets
+        ? onRelation.filter((t) => t.subjectRelation != null)
+        : [],
+    };
   }
 
   async findTuplesByRelation(

--- a/packages/core/tests/list-objects.test.ts
+++ b/packages/core/tests/list-objects.test.ts
@@ -3,7 +3,12 @@ import { check } from "../src/check.ts";
 import { DepthExceededError } from "../src/errors.ts";
 import { createTsfga } from "../src/index.ts";
 import { listObjects } from "../src/list-objects.ts";
-import type { RelationConfig, Tuple } from "../src/types.ts";
+import type {
+  CheckTuples,
+  CheckTuplesQuery,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
 import { delay, StoreReadFailure } from "./helpers/erroring-store.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
@@ -37,12 +42,12 @@ function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
 }
 
 /**
- * Every candidate check opens with a direct-tuple read on the
- * candidate object, which makes that read a usable proxy for "this
- * candidate has started". Stalling it parks each candidate at a
- * point where the pool's concurrency is observable, and failing it
- * fails exactly one candidate without disturbing the shared
- * subtree behind them all.
+ * Every candidate check opens with a tuple read on the candidate
+ * object, which makes that read a usable proxy for "this candidate
+ * has started". Stalling it parks each candidate at a point where
+ * the pool's concurrency is observable, and failing it fails
+ * exactly one candidate without disturbing the shared subtree
+ * behind them all.
  */
 class CandidateStore extends MockTupleStore {
   inFlight = 0;
@@ -53,25 +58,16 @@ class CandidateStore extends MockTupleStore {
   /** Candidate object id -> ms to stall before settling. */
   delays = new Map<string, number>();
 
-  override async findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
-    // A node reads its direct tuple and its wildcard tuple in one
-    // wave; instrument only the former, so one candidate counts
-    // as one in flight.
-    if (objectType !== "doc" || subjectId === "*") {
-      return super.findDirectTuple(
-        objectType,
-        objectId,
-        relation,
-        subjectType,
-        subjectId,
-      );
+  override async findCheckTuples(
+    query: CheckTuplesQuery,
+  ): Promise<CheckTuples> {
+    // Instrument only the candidate objects, so one candidate
+    // counts as one in flight and the shared subtree behind them
+    // is neither stalled nor failed.
+    if (query.objectType !== "doc") {
+      return super.findCheckTuples(query);
     }
+    const objectId = query.objectId;
     this.started.push(objectId);
     this.inFlight++;
     this.peakInFlight = Math.max(this.peakInFlight, this.inFlight);
@@ -81,13 +77,7 @@ class CandidateStore extends MockTupleStore {
       if (failure) {
         throw failure;
       }
-      return await super.findDirectTuple(
-        objectType,
-        objectId,
-        relation,
-        subjectType,
-        subjectId,
-      );
+      return await super.findCheckTuples(query);
     } finally {
       this.inFlight--;
     }
@@ -185,7 +175,7 @@ describe("listObjects", () => {
       });
 
       expect(
-        store.callsWith("findUsersetTuples", "folder", "shared", "member"),
+        store.callsWith("findCheckTuples", "folder", "shared", "member"),
       ).toBe(1);
     });
 
@@ -212,7 +202,7 @@ describe("listObjects", () => {
       }
 
       expect(
-        store.callsWith("findUsersetTuples", "folder", "shared", "member"),
+        store.callsWith("findCheckTuples", "folder", "shared", "member"),
       ).toBe(5);
     });
   });

--- a/packages/core/tests/read-gating.test.ts
+++ b/packages/core/tests/read-gating.test.ts
@@ -58,74 +58,78 @@ describe("structurally impossible reads are skipped", () => {
     return check(store, request);
   }
 
+  /**
+   * The one query the node under test sent, or `null` when it sent
+   * none at all.
+   */
+  function nodeQuery() {
+    return store.queriesFor("doc", "1", "viewer")[0] ?? null;
+  }
+
   describe("each read is gated on its own declaration", () => {
     test("a type list without the subject skips its probe", async () => {
-      await checkWith({ directlyAssignableTypes: ["team"] });
+      // Usersets stay allowed so a query is still sent — otherwise
+      // nothing is asked for at all and this would pass for the
+      // wrong reason. That case has its own test below.
+      await checkWith({
+        directlyAssignableTypes: ["team"],
+        allowsUsersetSubjects: true,
+      });
 
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "viewer",
-          "user",
-          "alice",
-        ),
-      ).toBe(0);
+      expect(nodeQuery()?.includeDirect).toBe(false);
     });
 
     test("a type list with the subject keeps its probe", async () => {
       await checkWith({ directlyAssignableTypes: ["user"] });
 
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "viewer",
-          "user",
-          "alice",
-        ),
-      ).toBe(1);
+      expect(nodeQuery()?.includeDirect).toBe(true);
     });
 
     test("no `type:*` in the list skips the wildcard probe", async () => {
       await checkWith({ directlyAssignableTypes: ["user"] });
 
-      expect(
-        store.callsWith("findDirectTuple", "doc", "1", "viewer", "user", "*"),
-      ).toBe(0);
+      expect(nodeQuery()?.includeWildcard).toBe(false);
     });
 
     test("`type:*` in the list keeps the wildcard probe", async () => {
       await checkWith({ directlyAssignableTypes: ["user", "user:*"] });
 
-      expect(
-        store.callsWith("findDirectTuple", "doc", "1", "viewer", "user", "*"),
-      ).toBe(1);
+      expect(nodeQuery()?.includeWildcard).toBe(true);
     });
 
     test("forbidding userset subjects skips the userset scan", async () => {
       await checkWith({ allowsUsersetSubjects: false });
 
-      expect(store.counts.findUsersetTuples).toBe(undefined);
+      expect(nodeQuery()?.includeUsersets).toBe(false);
     });
 
     test("allowing userset subjects keeps the userset scan", async () => {
       await checkWith({ allowsUsersetSubjects: true });
 
-      expect(store.counts.findUsersetTuples).toBe(1);
+      expect(nodeQuery()?.includeUsersets).toBe(true);
+    });
+
+    test("a relation that admits nothing sends no query", async () => {
+      // Nothing left to ask for, so the node skips the store
+      // rather than sending a query that cannot match.
+      await checkWith({
+        directlyAssignableTypes: [],
+        allowsUsersetSubjects: false,
+      });
+
+      expect(nodeQuery()).toBeNull();
     });
   });
 
   describe("only a positive exclusion skips a read", () => {
-    test("a null type list reads both probes", async () => {
+    test("a null type list asks for both probes", async () => {
       // `null` means the config declines to narrow the relation,
       // not that the relation is purely computed. Reading it as
       // "none" would skip probes for tuples `addTuple` accepts.
       await checkWith({ directlyAssignableTypes: null });
 
-      expect(store.counts.findDirectTuple).toBe(2);
+      expect(nodeQuery()?.includeDirect).toBe(true);
+      expect(nodeQuery()?.includeWildcard).toBe(true);
     });
 
     test("no config at all reads everything", async () => {
@@ -133,8 +137,9 @@ describe("structurally impossible reads are skipped", () => {
 
       await check(store, request);
 
-      expect(store.counts.findDirectTuple).toBe(2);
-      expect(store.counts.findUsersetTuples).toBe(1);
+      expect(nodeQuery()?.includeDirect).toBe(true);
+      expect(nodeQuery()?.includeWildcard).toBe(true);
+      expect(nodeQuery()?.includeUsersets).toBe(true);
     });
   });
 
@@ -256,26 +261,8 @@ describe("structurally impossible reads are skipped", () => {
       store.resetCounts();
 
       expect(await check(store, request)).toBe(true);
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "viewer",
-          "user",
-          "alice",
-        ),
-      ).toBe(0);
-      expect(
-        store.callsWith(
-          "findDirectTuple",
-          "doc",
-          "1",
-          "owner",
-          "user",
-          "alice",
-        ),
-      ).toBe(1);
+      expect(store.queriesFor("doc", "1", "viewer")).toEqual([]);
+      expect(store.queriesFor("doc", "1", "owner")).toHaveLength(1);
     });
   });
 });

--- a/packages/core/tests/store-trust.test.ts
+++ b/packages/core/tests/store-trust.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import type {
+  CheckTuples,
+  CheckTuplesQuery,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+const request = {
+  objectType: "doc",
+  objectId: "1",
+  relation: "viewer",
+  subjectType: "user",
+  subjectId: "alice",
+};
+
+/**
+ * A store that answers whatever it likes, ignoring the query's
+ * `include*` flags and filing rows wherever it wants.
+ *
+ * This is the adapter bug the merged read made possible. Under the
+ * old interface these cases were unreachable: the relation config
+ * was enforced by core *not calling* the method, so a store had no
+ * opportunity to return a row the model forbids. Sending the gates
+ * as flags moved that enforcement onto the store — unless core
+ * re-clamps the reply, which is what these tests exist to pin.
+ *
+ * Every case here must DENY. A grant is a fail-open: a tuple the
+ * model does not admit would be granting access.
+ */
+class RogueStore extends MockTupleStore {
+  constructor(private readonly reply: Partial<CheckTuples>) {
+    super();
+  }
+
+  /** The last query core actually sent, for gate assertions. */
+  lastQuery: CheckTuplesQuery | null = null;
+
+  override async findCheckTuples(
+    query: CheckTuplesQuery,
+  ): Promise<CheckTuples> {
+    // Only `doc:1#viewer` misbehaves. Nodes the check dispatches
+    // to — the team behind a userset row — answer honestly from
+    // the seeded tuples, so a grant there is a real grant and the
+    // tests below can tell "the clamp worked" apart from "the
+    // rogue reply happened to deny".
+    if (query.objectType !== "doc" || query.relation !== "viewer") {
+      return super.findCheckTuples(query);
+    }
+    this.lastQuery = query;
+    return {
+      direct: null,
+      wildcard: null,
+      usersets: [],
+      ...this.reply,
+    };
+  }
+}
+
+describe("a store cannot widen what the model admits", () => {
+  let store: RogueStore;
+
+  /** Push a `doc.viewer` config and check alice against it. */
+  function checkWith(config: Partial<RelationConfig>) {
+    store.relationConfigs.push(
+      makeConfig({ objectType: "doc", relation: "viewer", ...config }),
+    );
+    return check(store, request);
+  }
+
+  describe("ignoring an include flag loses the row", () => {
+    test("a direct tuple on a relation that forbids the type denies", async () => {
+      // The model says only `team` may hold viewer directly, so
+      // core sends includeDirect: false. The store answers anyway.
+      store = new RogueStore({ direct: makeTuple({ ...request }) });
+
+      expect(
+        await checkWith({
+          directlyAssignableTypes: ["team"],
+          allowsUsersetSubjects: true,
+        }),
+      ).toBe(false);
+      expect(store.lastQuery?.includeDirect).toBe(false);
+    });
+
+    test("a wildcard tuple on a relation without `type:*` denies", async () => {
+      store = new RogueStore({
+        wildcard: makeTuple({ ...request, subjectId: "*" }),
+      });
+
+      expect(
+        await checkWith({
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: true,
+        }),
+      ).toBe(false);
+      expect(store.lastQuery?.includeWildcard).toBe(false);
+    });
+
+    test("a userset row on a relation that forbids usersets denies", async () => {
+      // The dangerous one: an expanded userset dispatches to
+      // another node, so a grant here is reachable from a tuple
+      // the model never admitted.
+      store = new RogueStore({
+        usersets: [
+          makeTuple({
+            ...request,
+            subjectType: "team",
+            subjectId: "eng",
+            subjectRelation: "member",
+          }),
+        ],
+      });
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "team",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "team",
+          objectId: "eng",
+          relation: "member",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(
+        await checkWith({
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: false,
+        }),
+      ).toBe(false);
+      expect(store.lastQuery?.includeUsersets).toBe(false);
+    });
+  });
+
+  describe("a misfiled row loses its slot", () => {
+    test("another subject's tuple in the wildcard slot denies", async () => {
+      // The classifier bug the reference adapter's shape invites:
+      // alice's tuple filed as the wildcard would grant everyone.
+      store = new RogueStore({
+        wildcard: makeTuple({ ...request, subjectId: "alice" }),
+      });
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["user", "user:*"],
+        }),
+      );
+
+      // bob, not alice — a wildcard grant would apply to him.
+      expect(await check(store, { ...request, subjectId: "bob" })).toBe(false);
+    });
+
+    test("a tuple for another object denies", async () => {
+      store = new RogueStore({
+        direct: makeTuple({ ...request, objectId: "2" }),
+      });
+
+      expect(await checkWith({ directlyAssignableTypes: ["user"] })).toBe(
+        false,
+      );
+    });
+
+    test("a tuple for another relation denies", async () => {
+      store = new RogueStore({
+        direct: makeTuple({ ...request, relation: "editor" }),
+      });
+
+      expect(await checkWith({ directlyAssignableTypes: ["user"] })).toBe(
+        false,
+      );
+    });
+
+    test("a subject-relation row in the direct slot denies", async () => {
+      // A userset row is not a direct grant. Accepting it here
+      // would grant without ever resolving the userset.
+      store = new RogueStore({
+        direct: makeTuple({ ...request, subjectRelation: "member" }),
+      });
+
+      expect(await checkWith({ directlyAssignableTypes: ["user"] })).toBe(
+        false,
+      );
+    });
+
+    test("a direct row in the userset slot is not expanded", async () => {
+      store = new RogueStore({
+        usersets: [makeTuple({ ...request, subjectRelation: null })],
+      });
+
+      expect(
+        await checkWith({
+          directlyAssignableTypes: ["user"],
+          allowsUsersetSubjects: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("clamping does not disturb an honest store", () => {
+    test("the admitted rows still grant", async () => {
+      // The control: the clamp must reject only what is invalid.
+      store = new RogueStore({ direct: makeTuple({ ...request }) });
+
+      expect(await checkWith({ directlyAssignableTypes: ["user"] })).toBe(true);
+    });
+
+    test("a valid userset row is still expanded", async () => {
+      store = new RogueStore({
+        usersets: [
+          makeTuple({
+            ...request,
+            subjectType: "team",
+            subjectId: "eng",
+            subjectRelation: "member",
+          }),
+        ],
+      });
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "team",
+          relation: "member",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "team",
+          objectId: "eng",
+          relation: "member",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(
+        await checkWith({
+          directlyAssignableTypes: ["user", "team"],
+          allowsUsersetSubjects: true,
+        }),
+      ).toBe(true);
+    });
+
+    test("a wildcard grant still grants", async () => {
+      store = new RogueStore({
+        wildcard: makeTuple({ ...request, subjectId: "*" }),
+      });
+
+      expect(
+        await checkWith({ directlyAssignableTypes: ["user", "user:*"] }),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -5,6 +5,41 @@ Notable changes to `@tsfga/kysely`. The format is based on
 follow [Semantic Versioning](https://semver.org/) (pre-1.0: minor
 releases may contain breaking changes).
 
+## Unreleased
+
+### Breaking changes
+
+- **`KyselyTupleStore.findDirectTuple` and `findUsersetTuples` are
+  replaced by `findCheckTuples`**, following the same change to
+  the `TupleStore` interface in `@tsfga/core`. Code calling the
+  adapter directly (rather than through `createTsfga`) must be
+  updated; there is no fallback shim.
+
+  The three per-node reads a check used to make separately are now
+  one query: the same `(object_type, object_id, relation)`
+  predicate with an OR over only the subject predicates the caller
+  asked for. One round-trip instead of up to three, and one
+  connection instead of up to three held at once — which is where
+  the measured win comes from, since a wide node at the default
+  `maxBreadth` of 10 could otherwise demand 30 connections from
+  the pool.
+
+  Relations admitting more than one part resolve 1.8x–3.0x faster
+  on a 10-connection pool; relations admitting exactly one part
+  emit identical SQL and are unchanged.
+
+  The plan varies with the model shape: PostgreSQL uses an
+  `idx_tuples_check` prefix scan plus a filter in the general
+  case, and collapses to the full five-column index condition when
+  the disjuncts differ only in `subject_id` (the `[user, user:*]`
+  shape). One narrow window is worth knowing about: a relation
+  admitting both a direct type and usersets, on an object with
+  roughly 20–150 subjects, scans and discards rows the old direct
+  probe would have looked up exactly. Measured at 0.17 ms against
+  0.13 ms — still net faster, since the round-trip it removes
+  costs more than the difference — and above ~150 rows the planner
+  switches to a `BitmapOr` that closes the gap.
+
 ## 0.3.1 — 2026-08
 
 Maintenance release. No changes to the published code — the

--- a/packages/kysely/README.md
+++ b/packages/kysely/README.md
@@ -78,6 +78,35 @@ Migrations create a `tsfga` schema with three tables:
 | `tsfga.relation_configs` | Relation definitions (implied_by, computed_userset, etc.) |
 | `tsfga.condition_definitions` | Named CEL condition expressions |
 
+## How a check reads
+
+Every node of a check calls `findCheckTuples` once. The adapter
+serves it as a single query: one `(object_type, object_id,
+relation)` predicate with an OR over just the subject predicates
+the caller asked for — the subject's own direct tuple, the
+`type:*` wildcard tuple, the userset rows, or any subset.
+
+One round-trip per node instead of up to three, and one
+connection held instead of up to three. The latter is usually the
+bigger effect: branches of a node resolve concurrently up to
+`maxBreadth`, so three reads per node meant a wide node could ask
+the pool for three times as many connections as it has branches.
+
+Which plan PostgreSQL picks depends on the disjuncts. Asking for
+one part gives the same plan as before this was merged. Asking
+for a direct probe and a wildcard probe collapses to the full
+five-column `idx_tuples_check` condition, since they differ only
+in `subject_id`. Mixing a probe with the userset scan generally
+gives an `idx_tuples_check` prefix scan plus a filter, which
+reads a few rows it discards — cheaper than the round-trip it
+saves, but not free on objects with many subjects on one
+relation.
+
+Parts the caller excludes are omitted from the SQL, so they cost
+nothing to skip. Note this narrows the `Filter`, not the
+`Index Cond`, in the prefix-scan plan — the saving is in rows
+examined, not in index descent.
+
 ## License
 
 MIT

--- a/packages/kysely/src/adapter.ts
+++ b/packages/kysely/src/adapter.ts
@@ -1,5 +1,7 @@
 import {
   type AddTupleRequest,
+  type CheckTuples,
+  type CheckTuplesQuery,
   type ConditionDefinition,
   type ConditionParameterType,
   type IntersectionOperand,
@@ -46,44 +48,85 @@ function isConditionParameterType(
 export class KyselyTupleStore implements TupleStore {
   constructor(private db: Kysely<DB>) {}
 
-  async findDirectTuple(
-    objectType: string,
-    objectId: string,
-    relation: string,
-    subjectType: string,
-    subjectId: string,
-  ): Promise<Tuple | null> {
-    const dbSubjectId = subjectId === "*" ? WILDCARD_SENTINEL : subjectId;
-    const row = await this.db
-      .selectFrom("tsfga.tuples")
-      .selectAll()
-      .where("object_type", "=", objectType)
-      .where("object_id", "=", objectId)
-      .where("relation", "=", relation)
-      .where("subject_type", "=", subjectType)
-      .where("subject_id", "=", dbSubjectId)
-      .where("subject_relation", "is", null)
-      .executeTakeFirst();
+  /**
+   * All three per-node check reads in one round-trip.
+   *
+   * The parts share `(object_type, object_id, relation)` and
+   * differ only in their subject predicate, so they are one scan
+   * with an OR of the requested predicates rather than three
+   * queries. Only the requested disjuncts are emitted: an
+   * excluded part cannot match, so the planner never widens the
+   * scan for it, and nothing has to be filtered back out
+   * afterwards.
+   */
+  async findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    const { includeDirect, includeWildcard, includeUsersets } = query;
+    // Every part excluded means no row could be used. Return the
+    // empty result rather than a `WHERE false` round-trip.
+    if (!includeDirect && !includeWildcard && !includeUsersets) {
+      return { direct: null, wildcard: null, usersets: [] };
+    }
 
-    if (!row) return null;
-    return this.rowToTuple(row);
-  }
+    const dbSubjectId =
+      query.subjectId === "*" ? WILDCARD_SENTINEL : query.subjectId;
 
-  async findUsersetTuples(
-    objectType: string,
-    objectId: string,
-    relation: string,
-  ): Promise<Tuple[]> {
     const rows = await this.db
       .selectFrom("tsfga.tuples")
       .selectAll()
-      .where("object_type", "=", objectType)
-      .where("object_id", "=", objectId)
-      .where("relation", "=", relation)
-      .where("subject_relation", "is not", null)
+      .where("object_type", "=", query.objectType)
+      .where("object_id", "=", query.objectId)
+      .where("relation", "=", query.relation)
+      .where((eb) =>
+        eb.or([
+          ...(includeDirect
+            ? [
+                eb.and([
+                  eb("subject_type", "=", query.subjectType),
+                  eb("subject_id", "=", dbSubjectId),
+                  eb("subject_relation", "is", null),
+                ]),
+              ]
+            : []),
+          ...(includeWildcard
+            ? [
+                eb.and([
+                  eb("subject_type", "=", query.subjectType),
+                  eb("subject_id", "=", WILDCARD_SENTINEL),
+                  eb("subject_relation", "is", null),
+                ]),
+              ]
+            : []),
+          ...(includeUsersets ? [eb("subject_relation", "is not", null)] : []),
+        ]),
+      )
       .execute();
 
-    return rows.map((r) => this.rowToTuple(r));
+    let direct: Tuple | null = null;
+    let wildcard: Tuple | null = null;
+    const usersets: Tuple[] = [];
+
+    for (const row of rows) {
+      const tuple = this.rowToTuple(row);
+      if (row.subject_relation !== null) {
+        usersets.push(tuple);
+      } else if (includeDirect && row.subject_id === dbSubjectId) {
+        // Checked first, so a check *for* the wildcard subject —
+        // where both disjuncts are the same query — lands in
+        // `direct` rather than being reported twice.
+        direct = tuple;
+      } else if (includeWildcard && row.subject_id === WILDCARD_SENTINEL) {
+        wildcard = tuple;
+      }
+      // Partitioned on the raw column, never on the round-tripped
+      // tuple: `rowToTuple` maps the sentinel to `"*"`, so a real
+      // subject whose id happens to be the nil UUID would look
+      // like a wildcard here. Both arms are also positively
+      // matched rather than falling through to `wildcard`, so a
+      // row the query did not ask for is dropped instead of being
+      // filed under whichever slot is left.
+    }
+
+    return { direct, wildcard, usersets };
   }
 
   async findTuplesByRelation(

--- a/packages/kysely/tests/kysely-adapter.test.ts
+++ b/packages/kysely/tests/kysely-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   expect,
   test,
 } from "bun:test";
+import type { Tuple } from "@tsfga/core";
 import type { Kysely } from "kysely";
 import { KyselyTupleStore } from "../src/adapter.ts";
 import type { DB } from "../src/schema.ts";
@@ -16,6 +17,15 @@ import {
   getDb,
   rollbackTransaction,
 } from "./helpers/db.ts";
+
+/** Row order is not part of the read contract; compare as sets. */
+function sortedBySubject(tuples: readonly Tuple[]): Tuple[] {
+  return [...tuples].sort((a, b) =>
+    `${a.subjectType}:${a.subjectId}#${a.subjectRelation}`.localeCompare(
+      `${b.subjectType}:${b.subjectId}#${b.subjectRelation}`,
+    ),
+  );
+}
 
 describe("KyselyTupleStore", () => {
   let db: Kysely<DB>;
@@ -43,6 +53,31 @@ describe("KyselyTupleStore", () => {
   afterAll(async () => {
     await destroyDb();
   });
+
+  /**
+   * The direct probe on its own. Most read-back assertions want
+   * exactly one tuple by its natural key, which is one of the
+   * three parts `findCheckTuples` can serve.
+   */
+  async function readDirect(
+    objectType: string,
+    objectId: string,
+    relation: string,
+    subjectType: string,
+    subjectId: string,
+  ): Promise<Tuple | null> {
+    const { direct } = await store.findCheckTuples({
+      objectType,
+      objectId,
+      relation,
+      subjectType,
+      subjectId,
+      includeDirect: true,
+      includeWildcard: false,
+      includeUsersets: false,
+    });
+    return direct;
+  }
 
   describe("Relation configs", () => {
     test("upsertRelationConfig and findRelationConfig", async () => {
@@ -178,7 +213,7 @@ describe("KyselyTupleStore", () => {
   });
 
   describe("Tuples", () => {
-    test("insertTuple and findDirectTuple", async () => {
+    test("insertTuple then read back the direct probe", async () => {
       await store.insertTuple({
         objectType: "workspace",
         objectId: uuid1,
@@ -187,7 +222,7 @@ describe("KyselyTupleStore", () => {
         subjectId: uuid2,
       });
 
-      const tuple = await store.findDirectTuple(
+      const tuple = await readDirect(
         "workspace",
         uuid1,
         "member",
@@ -201,19 +236,13 @@ describe("KyselyTupleStore", () => {
       expect(tuple?.subjectRelation).toBeNull();
     });
 
-    test("findDirectTuple returns null for missing tuple", async () => {
+    test("the direct probe is null for a missing tuple", async () => {
       expect(
-        await store.findDirectTuple(
-          "workspace",
-          uuid1,
-          "member",
-          "user",
-          uuid2,
-        ),
+        await readDirect("workspace", uuid1, "member", "user", uuid2),
       ).toBeNull();
     });
 
-    test("findDirectTuple ignores tuples with subject_relation", async () => {
+    test("the direct probe ignores tuples with subject_relation", async () => {
       await store.insertTuple({
         objectType: "channel",
         objectId: uuid1,
@@ -224,17 +253,11 @@ describe("KyselyTupleStore", () => {
       });
 
       expect(
-        await store.findDirectTuple(
-          "channel",
-          uuid1,
-          "writer",
-          "workspace",
-          uuid2,
-        ),
+        await readDirect("channel", uuid1, "writer", "workspace", uuid2),
       ).toBeNull();
     });
 
-    test("findUsersetTuples", async () => {
+    test("the userset part returns only subject_relation rows", async () => {
       await store.insertTuple({
         objectType: "channel",
         objectId: uuid1,
@@ -252,9 +275,22 @@ describe("KyselyTupleStore", () => {
         subjectId: uuid3,
       });
 
-      const tuples = await store.findUsersetTuples("channel", uuid1, "writer");
-      expect(tuples).toHaveLength(1);
-      expect(tuples[0]?.subjectRelation).toBe("member");
+      const { direct, wildcard, usersets } = await store.findCheckTuples({
+        objectType: "channel",
+        objectId: uuid1,
+        relation: "writer",
+        subjectType: "user",
+        subjectId: uuid3,
+        includeDirect: false,
+        includeWildcard: false,
+        includeUsersets: true,
+      });
+      expect(usersets).toHaveLength(1);
+      expect(usersets[0]?.subjectRelation).toBe("member");
+      // The parts the query excluded stay empty even though rows
+      // matching them exist.
+      expect(direct).toBeNull();
+      expect(wildcard).toBeNull();
     });
 
     test("findTuplesByRelation returns all tuples", async () => {
@@ -300,7 +336,7 @@ describe("KyselyTupleStore", () => {
         conditionName: "new_cond",
       });
 
-      const tuple = await store.findDirectTuple(
+      const tuple = await readDirect(
         "workspace",
         uuid1,
         "member",
@@ -321,13 +357,7 @@ describe("KyselyTupleStore", () => {
         conditionContext: { region: "us" },
       });
 
-      const tuple = await store.findDirectTuple(
-        "doc",
-        uuid1,
-        "viewer",
-        "user",
-        uuid2,
-      );
+      const tuple = await readDirect("doc", uuid1, "viewer", "user", uuid2);
       expect(tuple?.conditionName).toBe("in_region");
       expect(tuple?.conditionContext).toEqual({ region: "us" });
     });
@@ -352,13 +382,7 @@ describe("KyselyTupleStore", () => {
       ).toBe(true);
 
       expect(
-        await store.findDirectTuple(
-          "workspace",
-          uuid1,
-          "member",
-          "user",
-          uuid2,
-        ),
+        await readDirect("workspace", uuid1, "member", "user", uuid2),
       ).toBeNull();
     });
 
@@ -407,7 +431,7 @@ describe("KyselyTupleStore", () => {
         subjectId: uuid2,
       });
 
-      const tuple = await store.findDirectTuple(
+      const tuple = await readDirect(
         "workspace",
         uuid1,
         "member",
@@ -437,13 +461,7 @@ describe("KyselyTupleStore", () => {
         conditionName: null,
       });
 
-      const tuple = await store.findDirectTuple(
-        "doc",
-        uuid1,
-        "viewer",
-        "user",
-        uuid2,
-      );
+      const tuple = await readDirect("doc", uuid1, "viewer", "user", uuid2);
       expect(tuple?.conditionName).toBeNull();
     });
 
@@ -467,13 +485,7 @@ describe("KyselyTupleStore", () => {
         conditionContext: null,
       });
 
-      const tuple = await store.findDirectTuple(
-        "doc",
-        uuid1,
-        "viewer",
-        "user",
-        uuid2,
-      );
+      const tuple = await readDirect("doc", uuid1, "viewer", "user", uuid2);
       expect(tuple?.conditionContext).toBeNull();
     });
 
@@ -574,7 +586,7 @@ describe("KyselyTupleStore", () => {
       expect(row?.subject_id).toBe(sentinel);
     });
 
-    test("findDirectTuple maps the sentinel back to *", async () => {
+    test("the direct probe maps the sentinel back to *", async () => {
       await store.insertTuple({
         objectType: "doc",
         objectId: uuid1,
@@ -583,13 +595,7 @@ describe("KyselyTupleStore", () => {
         subjectId: "*",
       });
 
-      const tuple = await store.findDirectTuple(
-        "doc",
-        uuid1,
-        "viewer",
-        "user",
-        "*",
-      );
+      const tuple = await readDirect("doc", uuid1, "viewer", "user", "*");
       expect(tuple).not.toBeNull();
       expect(tuple?.subjectId).toBe("*");
     });
@@ -648,9 +654,140 @@ describe("KyselyTupleStore", () => {
           subjectId: "*",
         }),
       ).toBe(true);
-      expect(
-        await store.findDirectTuple("doc", uuid1, "viewer", "user", "*"),
-      ).toBeNull();
+      expect(await readDirect("doc", uuid1, "viewer", "user", "*")).toBeNull();
+    });
+  });
+
+  /**
+   * The merged read has to return exactly the rows the three
+   * separate predicates would have. The oracle here is
+   * `findTuplesByRelation`, which returns every row on the
+   * object+relation and is independent of the query being tested:
+   * partitioning its output by the same three predicates gives the
+   * expected answer without reusing the code under test.
+   *
+   * Run over every combination of the three flags, on a fixture
+   * that puts a matching row in each part plus rows that must not
+   * be picked up — a different subject, a different subject type,
+   * a different relation.
+   */
+  describe("the merged read agrees with the predicates it replaces", () => {
+    const parts = [false, true];
+
+    async function seed() {
+      const rows = [
+        // The subject's own direct tuple.
+        { subjectType: "user", subjectId: uuid2 },
+        // The public wildcard.
+        { subjectType: "user", subjectId: "*" },
+        // Two usersets.
+        { subjectType: "team", subjectId: uuid3, subjectRelation: "member" },
+        { subjectType: "team", subjectId: uuid1, subjectRelation: "owner" },
+        // Must never be returned: another subject of the same
+        // type, and a wildcard of a different type.
+        { subjectType: "user", subjectId: uuid3 },
+        { subjectType: "robot", subjectId: "*" },
+      ];
+      for (const row of rows) {
+        await store.insertTuple({
+          objectType: "doc",
+          objectId: uuid1,
+          relation: "viewer",
+          ...row,
+        });
+      }
+      // Same object, different relation — out of scope entirely.
+      await store.insertTuple({
+        objectType: "doc",
+        objectId: uuid1,
+        relation: "editor",
+        subjectType: "user",
+        subjectId: uuid2,
+      });
+    }
+
+    for (const includeDirect of parts) {
+      for (const includeWildcard of parts) {
+        for (const includeUsersets of parts) {
+          const label = [
+            includeDirect ? "direct" : null,
+            includeWildcard ? "wildcard" : null,
+            includeUsersets ? "usersets" : null,
+          ]
+            .filter((part) => part !== null)
+            .join("+");
+
+          test(`${label || "nothing"} requested`, async () => {
+            await seed();
+
+            const all = await store.findTuplesByRelation(
+              "doc",
+              uuid1,
+              "viewer",
+            );
+            const expected = {
+              direct: includeDirect
+                ? (all.find(
+                    (t) =>
+                      t.subjectType === "user" &&
+                      t.subjectId === uuid2 &&
+                      t.subjectRelation === null,
+                  ) ?? null)
+                : null,
+              wildcard: includeWildcard
+                ? (all.find(
+                    (t) =>
+                      t.subjectType === "user" &&
+                      t.subjectId === "*" &&
+                      t.subjectRelation === null,
+                  ) ?? null)
+                : null,
+              usersets: includeUsersets
+                ? all.filter((t) => t.subjectRelation !== null)
+                : [],
+            };
+
+            const actual = await store.findCheckTuples({
+              objectType: "doc",
+              objectId: uuid1,
+              relation: "viewer",
+              subjectType: "user",
+              subjectId: uuid2,
+              includeDirect,
+              includeWildcard,
+              includeUsersets,
+            });
+
+            expect(actual.direct).toEqual(expected.direct);
+            expect(actual.wildcard).toEqual(expected.wildcard);
+            // Row order is not part of the contract; compare as
+            // sets keyed by the subject.
+            expect(sortedBySubject(actual.usersets)).toEqual(
+              sortedBySubject(expected.usersets),
+            );
+          });
+        }
+      }
+    }
+
+    test("a wildcard subject lands in the direct slot, not both", async () => {
+      // Checking `user:*` itself makes the two probes the same
+      // query. It must be reported once, and as the direct hit.
+      await seed();
+
+      const result = await store.findCheckTuples({
+        objectType: "doc",
+        objectId: uuid1,
+        relation: "viewer",
+        subjectType: "user",
+        subjectId: "*",
+        includeDirect: true,
+        includeWildcard: true,
+        includeUsersets: false,
+      });
+
+      expect(result.direct?.subjectId).toBe("*");
+      expect(result.wildcard).toBeNull();
     });
   });
 

--- a/packages/kysely/tests/stored-data.test.ts
+++ b/packages/kysely/tests/stored-data.test.ts
@@ -204,7 +204,16 @@ describe("Invalid stored data", () => {
         .execute();
 
       await expect(
-        store.findDirectTuple("doc", uuid1, "viewer", "user", uuid2),
+        store.findCheckTuples({
+          objectType: "doc",
+          objectId: uuid1,
+          relation: "viewer",
+          subjectType: "user",
+          subjectId: uuid2,
+          includeDirect: true,
+          includeWildcard: false,
+          includeUsersets: false,
+        }),
       ).rejects.toBeInstanceOf(InvalidStoredDataError);
     });
   });

--- a/tests/smoke/smoke-test.mjs
+++ b/tests/smoke/smoke-test.mjs
@@ -15,19 +15,28 @@ import { createTsfga, check } from "../../packages/core/dist/index.js";
 assert(typeof createTsfga === "function", "createTsfga should be a function");
 assert(typeof check === "function", "check should be a function");
 
-// Minimal mock store (only methods used by a simple direct-tuple check)
+// Minimal mock store (only methods used by a simple direct-tuple
+// check). `findCheckTuples` answers all three per-node reads at
+// once; a store may use the query's include* flags to skip work,
+// but core re-clamps the reply, so returning a slot that was not
+// asked for just loses it.
 const mockStore = {
-  findDirectTuple: async (_objectType, _objectId, _relation, _subjectType, _subjectId) => ({
-    objectType: "doc",
-    objectId: "1",
-    relation: "viewer",
-    subjectType: "user",
-    subjectId: "alice",
-    subjectRelation: null,
-    conditionName: null,
-    conditionContext: null,
+  findCheckTuples: async (query) => ({
+    direct: query.includeDirect
+      ? {
+          objectType: query.objectType,
+          objectId: query.objectId,
+          relation: query.relation,
+          subjectType: query.subjectType,
+          subjectId: query.subjectId,
+          subjectRelation: null,
+          conditionName: null,
+          conditionContext: null,
+        }
+      : null,
+    wildcard: null,
+    usersets: [],
   }),
-  findUsersetTuples: async () => [],
   findTuplesByRelation: async () => [],
   findRelationConfig: async () => null,
   findConditionDefinition: async () => null,
@@ -56,7 +65,11 @@ assert(allowed === true, `expected true, got ${allowed}`);
 // No matching tuple — should return false
 const notAllowedStore = {
   ...mockStore,
-  findDirectTuple: async () => null,
+  findCheckTuples: async () => ({
+    direct: null,
+    wildcard: null,
+    usersets: [],
+  }),
 };
 const notAllowedClient = createTsfga(notAllowedStore);
 const denied = await notAllowedClient.check({


### PR DESCRIPTION
## Summary

- Replaces `TupleStore.findDirectTuple` and `findUsersetTuples` with a
  single `findCheckTuples(query)`, so a check node makes one store call
  instead of three. Breaking, no fallback shim, per the pre-v1 policy;
  `CheckTuplesQuery` and `CheckTuples` are exported for third-party
  store implementors, and `CHANGELOG.md` carries a porting snippet.
- Latency change, not a work change — the same rows are read. What
  drops is round-trips and connection-pool pressure: a node used to
  issue up to three concurrent reads, so at the default `maxBreadth` of
  10 a wide node could demand 30 connections at once, and now demands
  10. Against PostgreSQL on a 10-connection pool, relations admitting
  more than one part (`[user, group#member]`) resolve 1.8x-3.0x faster;
  single-part relations emit identical SQL and are unchanged.
- The relation-config gating rides along as `includeDirect` /
  `includeWildcard` / `includeUsersets`, so it now narrows the SQL
  rather than filtering the result. Those flags are a **narrowing hint,
  not a trust boundary**: `clampToQuery` re-applies the query to the
  reply, so a store that ignores a flag or misfiles a row loses that row
  rather than granting past the model's type restrictions. This
  replaces an enforcement that used to come free from *not making the
  call*, and mirrors upstream's handler-selection plus
  `validation.FilterInvalidTuples`.

Two known trade-offs are documented rather than glossed. A multi-part
relation on an object with roughly 20-150 subjects loses the exact
five-column index condition and discards rows the old probe would not
have (0.17ms vs 0.13ms, measured warm; the planner's BitmapOr closes it
above ~150). And `clampToQuery` denies silently — safe, but a custom
adapter's classifier bug surfaces as a phantom `false` rather than an
error.

`ContextualTupleStore` is unchanged in behavior. Its overlay is
deliberately asymmetric — a probe returns one tuple so a contextual one
*replaces* it, while usersets are a set and are concatenated — which
the merge makes easy to even out by accident, so both directions now
have tests.

## Test plan

- [x] `bun run turbo:test` — core 205, kysely 58, conformance 362
- [x] New `packages/core/tests/store-trust.test.ts`: 11 tests pinning
      that a rogue store cannot widen what the model admits.
      Mutation-verified — removing `clampToQuery` fails 7 of them, every
      one a grant
- [x] Kysely adapter row-set equivalence with the three predicates it
      replaces, over all eight flag combinations, using
      `findTuplesByRelation` as an independent oracle
- [x] Contextual overlay asymmetry covered in both directions, plus that
      a probe the overlay answers is dropped from the inner query
- [x] `bun run tsc`, `bun run biome:check`
- [x] CI green on all 12 jobs (Bun 1.2/1.3, Node 22/24/26, Deno 2.6/2.9,
      lint, typecheck, packaging, examples)