### PR TITLE
Drop the unreachable metadata columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ tsfga/
 │       │   └── migrations/
 │       │       ├── 001-initial.ts
 │       │       ├── 002-add-operators.ts
-│       │       └── 003-drop-unused-indexes.ts
+│       │       ├── 003-drop-unused-indexes.ts
+│       │       └── 004-drop-metadata-columns.ts
 │       ├── tests/
 │       │   ├── kysely-adapter.test.ts
 │       │   └── helpers/
@@ -566,9 +567,18 @@ export class ConditionEvaluationError extends TsfgaError {
 
 Creates the `tsfga` schema with 3 tables and 7 indexes on
 `tsfga.tuples`; migration `003-drop-unused-indexes` later removes
-three of them, leaving 4. Uses Kysely's DDL schema builder API
+three of them, leaving 4, and `004-drop-metadata-columns` removes
+the unreachable `metadata` column from `tsfga.tuples` and
+`tsfga.relation_configs`. Uses Kysely's DDL schema builder API
 where possible; raw `sql` only for indexes the builder cannot
 express.
+
+**Every column must be reachable through the library.** A column
+no `@tsfga/core` type carries and no adapter method reads or
+writes cannot be populated by anything tsfga does, and the
+exported `DB` type turns it into an accidental out-of-band API.
+That is what happened to `metadata`, ported in from a predecessor
+schema and never wired to anything.
 
 **Every index must earn its place on a query the adapter actually
 issues.** Prefix redundancy alone is not a reason to drop one — a
@@ -584,7 +594,9 @@ the DDL (expression indexes, GIN + WHERE combos).
 
 **What stays as raw SQL:**
 - `idx_tuples_unique` — uses `COALESCE(subject_relation, '')` expression
-- `idx_tuples_metadata` — uses `USING GIN` with a `WHERE` clause
+- `idx_tuples_metadata` in `001` and its `003` rollback — uses
+  `USING GIN` with a `WHERE` clause. Both are history: the index
+  is dropped in `003` and the column it covered in `004`.
 
 **Migration management** uses `kysely-ctl` with config in
 `packages/kysely/kysely.config.ts`:

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -57,7 +57,13 @@ releases may contain breaking changes).
   - `idx_tuples_metadata` — a GIN index on a column the adapter
     never writes or reads.
   - `idx_tuples_condition` — `condition_name` is written and
-    projected, but never appears in a predicate.
+    projected, but never appears in a predicate in any adapter
+    query. OpenFGA does filter on condition name, via
+    `COALESCE(condition_name, '') IN (...)`, yet indexes the
+    column in no dialect and on neither its tuple nor its
+    changelog table — the predicate always trails an equality on
+    the object columns. A bare-column index could not have served
+    that expression anyway.
 
   `idx_tuples_object` and `idx_tuples_userset` are prefixes of
   `idx_tuples_unique` too, and were evaluated for the same
@@ -69,6 +75,25 @@ releases may contain breaking changes).
   against 16, with 400 rows filtered out that the partial index
   excludes outright. Prefix redundancy alone does not make an
   index free to drop.
+
+- **Migration `004-drop-metadata-columns` removes the `metadata`
+  column from `tsfga.tuples` and `tsfga.relation_configs`**, and
+  the generated `DB` type no longer carries it.
+
+  Neither column was reachable through the library: `@tsfga/core`
+  has no metadata concept on `Tuple` or `RelationConfig`, and no
+  adapter method wrote, read, or filtered it. Nothing tsfga does
+  could put a value there. It came in from a predecessor schema
+  and was never wired to anything; OpenFGA has no analogue on its
+  tuple table in any dialect, so it was not anticipating a
+  feature either.
+
+  **Destructive, and `down` restores the columns but not their
+  contents.** This only matters for a consumer who wrote to them
+  out of band through their own `Kysely<DB>` handle — possible,
+  and type-visible, because the exported `DB` type declared the
+  columns even though no adapter method touched them. Copy any
+  such data out before migrating.
 
 ## 0.3.1 — 2026-08
 

--- a/packages/kysely/src/migrations/004-drop-metadata-columns.ts
+++ b/packages/kysely/src/migrations/004-drop-metadata-columns.ts
@@ -1,0 +1,48 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Drops the `metadata` column from `tsfga.tuples` and
+ * `tsfga.relation_configs`.
+ *
+ * Neither column was reachable through the library. `@tsfga/core`
+ * has no metadata concept on `Tuple` or `RelationConfig`, and the
+ * adapter never wrote, read, or filtered the column — it appeared
+ * only in the generated `schema.ts`. Nothing tsfga does could
+ * populate it.
+ *
+ * Destructive, and not fully reversible: `down` restores the
+ * columns but not their contents. That matters only for a
+ * consumer who wrote to them out of band through their own
+ * `Kysely<DB>` handle, since the exported `DB` type made the
+ * columns type-visible even though no adapter method touched
+ * them. Such a consumer should copy the data out before
+ * migrating.
+ *
+ * The GIN index that covered `tuples.metadata` is already gone,
+ * dropped in `003-drop-unused-indexes`.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("tsfga.tuples").dropColumn("metadata").execute();
+
+  await db.schema
+    .alterTable("tsfga.relation_configs")
+    .dropColumn("metadata")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("tsfga.tuples")
+    .addColumn("metadata", "jsonb")
+    .execute();
+
+  await db.schema
+    .alterTable("tsfga.relation_configs")
+    .addColumn("metadata", "jsonb")
+    .execute();
+
+  // No index to restore here: `003-drop-unused-indexes` owns
+  // `idx_tuples_metadata`, and rolling back reaches this
+  // migration first, so the column is back before that `down`
+  // recreates the index on it.
+}

--- a/packages/kysely/src/migrations/index.ts
+++ b/packages/kysely/src/migrations/index.ts
@@ -2,6 +2,7 @@ import type { Migration, MigrationProvider } from "kysely/migration";
 import * as initial from "./001-initial.ts";
 import * as addOperators from "./002-add-operators.ts";
 import * as dropUnusedIndexes from "./003-drop-unused-indexes.ts";
+import * as dropMetadataColumns from "./004-drop-metadata-columns.ts";
 
 /**
  * All tsfga schema migrations, keyed by name in execution order.
@@ -12,6 +13,7 @@ export const migrations: Record<string, Migration> = {
   "001-initial": initial,
   "002-add-operators": addOperators,
   "003-drop-unused-indexes": dropUnusedIndexes,
+  "004-drop-metadata-columns": dropMetadataColumns,
 };
 
 /**

--- a/packages/kysely/src/schema.ts
+++ b/packages/kysely/src/schema.ts
@@ -40,7 +40,6 @@ export interface TsfgaRelationConfigs {
   id: Generated<Int8>;
   implied_by: string[] | null;
   intersection: Json | null;
-  metadata: Json | null;
   object_type: string;
   relation: string;
   tuple_to_userset: Json | null;
@@ -51,7 +50,6 @@ export interface TsfgaTuples {
   condition_name: string | null;
   created_at: Timestamp;
   id: Generated<Int8>;
-  metadata: Json | null;
   object_id: string;
   object_type: string;
   relation: string;


### PR DESCRIPTION
## Summary

- Adds migration `004-drop-metadata-columns`, removing the `metadata jsonb`
  column from `tsfga.tuples` and `tsfga.relation_configs`. The generated
  `DB` type no longer carries it.
- **Nothing in the library could reach either column.** `@tsfga/core` has
  no metadata concept on `Tuple` or `RelationConfig` — the word does not
  appear in the package at all — and no adapter method wrote, read, or
  filtered it. It showed up only in the generated `schema.ts`, so every
  row's metadata was NULL, necessarily.
- Checked upstream before removing rather than after: OpenFGA has no
  metadata column on its tuple table in any dialect and no metadata field
  on any tuple protobuf, so this was not anticipating a feature we had yet
  to build. The three `Metadata` types OpenFGA does have are unrelated —
  model `RelationMetadata`, a query-count instrumentation struct, and
  `ConditionMetadata`.
- The GIN index over the column went in #71, on the narrower ground that
  no query could use it. This removes the column itself, which is *why*
  no query could.

Also corrects what #71 said about `idx_tuples_condition`. "Never appears
in a predicate" is true of this adapter but reads as a claim about the
general case, and OpenFGA *does* filter on condition name via
`COALESCE(condition_name, '') IN (...)`. It simply indexes the column
nowhere — not in any of the three dialects, and not on the changelog
table either. A bare-column index could not have served that expression
regardless.

## Compatibility

**Destructive, and `down` restores the columns but not their contents.**
This is a real exposure for one kind of consumer: the exported `DB` type
declared these columns, so someone holding their own `Kysely<DB>` handle
— which every consumer does, since the adapter receives its connection
rather than owning it — could have written to them out of band. An
unreachable column plus an exported type is an accidental API. The
changelog tells such users to copy the data out before migrating.

## Test plan

- [x] `up` then `down` verified: both columns return as nullable `jsonb`,
      matching their original definitions
- [x] Full rebuild from an empty database (`db:rollback` + `db:latest`)
      through all four migrations lands on the intended end state — 4
      indexes, no `metadata` column on either table
- [x] `db:generate` regenerated `schema.ts`; the diff is exactly the two
      removed fields
- [x] `bun run turbo:test` — core 205, kysely 58, conformance 362
- [x] `bun run tsc`, `bun run biome:check`
- [x] CI green on all 12 jobs