### PR TITLE
Bump packages to 0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,7 +659,7 @@ export interface TsfgaClient {
   check(request: CheckRequest): Promise<boolean>;
   addTuple(request: AddTupleRequest): Promise<void>;
   removeTuple(request: RemoveTupleRequest): Promise<boolean>;
-  listObjects(objectType: string, relation: string, subjectType: string, subjectId: string): Promise<string[]>;
+  listObjects(objectType: string, relation: string, subjectType: string, subjectId: string, context?: Record<string, unknown>): Promise<string[]>;
   listSubjects(objectType: string, objectId: string, relation: string): Promise<Array<{ subjectType: string; subjectId: string; subjectRelation?: string }>>;
   writeRelationConfig(config: RelationConfig): Promise<void>;
   deleteRelationConfig(objectType: string, relation: string): Promise<boolean>;

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/core": {
       "name": "@tsfga/core",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@marcbachmann/cel-js": "8.0.0",
       },
@@ -29,7 +29,7 @@
     },
     "packages/kysely": {
       "name": "@tsfga/kysely",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "devDependencies": {
         "@tsfga/core": "workspace:*",
         "@types/bun": "1.3.14",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes to `@tsfga/core`. The format is based on
 follow [Semantic Versioning](https://semver.org/) (pre-1.0: minor
 releases may contain breaking changes).
 
-## Unreleased
+## 0.4.0 — 2026-08
 
 ### Breaking changes
 
@@ -98,7 +98,100 @@ releases may contain breaking changes).
   only case where that is observable is the subtract side of a
   `but not`, where OpenFGA grants and tsfga denies.
 
+- **A condition evaluated with missing declared parameters is now
+  an error, not an unmet condition.** A tuple whose condition
+  declares a parameter that neither the tuple context nor the
+  request context supplies used to resolve `false`; it now throws
+  `ConditionEvaluationError` naming the absent keys, matching
+  OpenFGA's check path. The difference is not cosmetic: a
+  silently-unmet condition fails open through an exclusion
+  branch, where "not excluded" grants. Callers that relied on a
+  missing parameter reading as a denial must supply the
+  parameter, or catch the error.
+
+- **A definitive denial now outranks a sibling error in
+  intersection and exclusion.** Unions already let a branch
+  resolving `true` beat an errored sibling; the other two
+  operators rejected as soon as any branch did. As in OpenFGA,
+  an intersection operand resolving `false` now denies even
+  though another operand errored, and an exclusion whose
+  subtracted branch resolves `true` denies even though the base
+  errored — only a base that *granted* alongside an errored
+  exclusion branch still propagates. Checks that used to reject
+  now resolve `false`; the theopenlane fixtures hit exactly this
+  through `member and access`, where a conditioned tuple with
+  missing parameters inside one operand poisoned a check OpenFGA
+  resolves. The fail-closed invariant holds throughout: an error
+  never becomes a grant, only definitive denials win past one.
+
+  When several branches do fail, which error surfaces follows
+  completion order, so it is not deterministic under concurrency
+  — the same nondeterminism OpenFGA's union reducer has.
+
+### Added
+
+- **`CheckOptions.maxBreadth`** bounds how many branches of one
+  resolution node are evaluated concurrently, mirroring
+  OpenFGA's `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`. It **defaults
+  to 10**, that option's upstream default; before this release
+  fanout was unbounded, so a union over 1k userset tuples issued
+  1k concurrent sub-checks and ran every one to completion even
+  after a branch had granted. Pass `maxBreadth: Infinity` to
+  restore the old behavior.
+
+  Bounding changes scheduling, not answers: the boolean result
+  and whether a check errors are unaffected, and the core,
+  adapter, and conformance suites pass unchanged at the new
+  default. On a 1k-branch union that grants, the bound cuts the
+  benchmark from ~270 ms/3005 store calls to ~108 ms/1166; a
+  100-branch TTU hit goes from ~41 ms/306 to ~17 ms/192. The one
+  measured regression is all-miss wide unions under concurrent
+  load (~20% slower batch wall time for four parallel 1k-branch
+  misses), where unbounded fanout kept the pool queue full —
+  `Infinity` restores it for miss-heavy workloads.
+
+  Exclusion keeps a fixed breadth of 2, as upstream does. Values
+  other than an integer >= 1 or `Infinity` throw `TsfgaError`;
+  a fractional bound would admit one more branch than stated.
+
+  `maxBreadth` also bounds how many `listObjects` candidates are
+  checked at once, following upstream, whose ListObjects worker
+  pool is sized from the same limit.
+
 ### Changed
+
+- **`maxDepth` now defaults to 25 instead of 10**, matching
+  OpenFGA's `OPENFGA_RESOLVE_NODE_LIMIT`. The old default threw
+  `DepthExceededError` on models a stock OpenFGA server resolves,
+  so deep models needed an explicit override to conform. Callers
+  who passed `maxDepth: 25` for that reason can drop it.
+
+- **Relation configs and condition definitions are read once per
+  check request.** Both are static per authorization model, but
+  every resolution node re-fetched them — on a 1000-branch
+  userset fanout, ~1000 redundant round-trips, a quarter of all
+  store calls. An internal request-scoped cache now memoizes
+  both, including negative results, and coalesces concurrent
+  branches asking the same key onto one in-flight query; a
+  failed read is evicted rather than pinned, so a later branch
+  retries. The cache lives for one `check` call, so a config
+  written between two checks is always observed; a write racing
+  a check in flight may not be. Measured against PostgreSQL, a
+  1000-branch fanout dropped from 4004 to 3005 store calls and
+  365 ms to 260 ms.
+
+- **A node reached by two routes in one request resolves once.**
+  The check graph is a DAG explored as a tree, so a shared
+  subtree was re-resolved per route. A request-scoped memo now
+  publishes settled node results only — never in-flight promises,
+  which deadlock on a cross-branch cycle — and only results that
+  are not cycle-truncated, since a truncated `false` is
+  path-dependent. Reuse is gated on the depth an entry was proved
+  at, so a memo hit can never answer where a fresh resolution
+  would have thrown `DepthExceededError`. At the default breadth
+  a whole level is in flight before any of it settles, so the
+  memo mostly pays inside `listObjects`, where it spans every
+  candidate.
 
 - **Only dispatches to another object spend the depth budget.**
   Userset expansion and tuple-to-userset expansion cost one depth
@@ -164,6 +257,16 @@ releases may contain breaking changes).
   single overlapping read wave, also unreleased. The cost is one
   round-trip per relation per request, not per node, because
   configs are cached for the request.
+
+### Fixed
+
+- **An intersection with zero operands no longer grants.** A
+  malformed config with an empty `intersection` array resolved
+  vacuously `true`, granting the relation to every subject. It
+  now throws `TsfgaError`; OpenFGA's typesystem rejects a set
+  operation with too few children as an invalid model.
+  Single-operand intersections stay valid — tsfga's decomposed
+  configs use them legitimately.
 
 ## 0.3.1 — 2026-08
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsfga/core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "author": "Lemuel Roberto Bonifacio <code@lemuelroberto.online>",
   "description": "OpenFGA-compatible relationship-based access control for TypeScript",

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -5,9 +5,14 @@ Notable changes to `@tsfga/kysely`. The format is based on
 follow [Semantic Versioning](https://semver.org/) (pre-1.0: minor
 releases may contain breaking changes).
 
-## Unreleased
+## 0.4.0 — 2026-08
 
 ### Breaking changes
+
+- **Requires `@tsfga/core` 0.4.0 or later.** The adapter
+  implements the reshaped `TupleStore` interface below, so a
+  0.3.x core cannot drive it; the peer range is bumped
+  accordingly.
 
 - **`KyselyTupleStore.findDirectTuple` and `findUsersetTuples` are
   replaced by `findCheckTuples`**, following the same change to

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsfga/kysely",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "author": "Lemuel Roberto Bonifacio <code@lemuelroberto.online>",
   "description": "Kysely/PostgreSQL adapter for @tsfga/core",


### PR DESCRIPTION
Prepares the 0.4.0 release of `@tsfga/core` and `@tsfga/kysely`.
No source changes — version bumps and changelogs only.

## Changelog gaps

Six commits merged since 0.3.1 shipped without a changelog entry,
all from the earlier round of resolve-node work:

| Commit | Now recorded as |
|--------|-----------------|
| `611c2b1` | Changed — `maxDepth` default 10 → 25 |
| `d7d5453` | Changed — request-scoped config/condition cache |
| `4082c4d` | Breaking — condition and sibling-error semantics |
| `120866e` `e8ea917` `c003388` | Added — `maxBreadth`, default 10 |
| `bedfbd7` | Changed — per-request memo of settled node results |

Two of those are behavior-breaking for callers and had no record
at all: a condition missing a declared parameter now raises
`ConditionEvaluationError` where it used to read as unmet, and a
definitive denial now outranks a sibling error in intersection and
exclusion. Unions already let a grant beat an errored sibling
before 0.3.1, so the entry is scoped to the two operators that
actually changed.

The empty-intersection fail-open is filed under Fixed — verified
against the 0.3.1 source, where a zero-operand `intersection`
resolved vacuously `true` and granted the relation to every
subject.

`616dab0` (single read wave) deliberately gets no entry: `9e3e096`
reverted that ordering and the existing text already says so.

## Peer range

`@tsfga/kysely`'s `workspace:*` peer on core publishes as
`^0.4.0`, which is what the adapter needs — it implements the
reshaped `TupleStore` and a 0.3.x core cannot drive it. Stated in
its changelog so the constraint is not just implicit in the
manifest.

## Also

- `CLAUDE.md`'s `TsfgaClient` signature never picked up the
  `listObjects` `context` parameter added in 0.3.0.
- `examples/node-kysely` still pins 0.3.0. CI resolves the
  examples from npm rather than the checkout, so it cannot move
  until 0.4.0 is published.

## Validation

Lint, typecheck, core (205), kysely (58) and conformance (362)
suites pass locally; `publint` and `attw --profile esm-only` are
clean for both tarballs. CI green on the fork:
https://github.com/lemuelroberto/tsfga/actions/runs/31329697926