### PR TITLE
Resolve each check node once, and share a scope across a batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ following methods:
 | Method | Description |
 |---|---|
 | `check(request)` | Check if a subject has a relation on an object |
+| `checkMany(requests)` | Check several requests in one shared resolution scope |
 | `addTuple(request)` | Insert or update a relationship tuple |
 | `removeTuple(request)` | Delete a relationship tuple |
 | `listObjects(objectType, relation, subjectType, subjectId)` | List object IDs the subject can access |

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/core": {
       "name": "@tsfga/core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@marcbachmann/cel-js": "8.0.0",
       },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,92 @@ Notable changes to `@tsfga/core`. The format is based on
 follow [Semantic Versioning](https://semver.org/) (pre-1.0: minor
 releases may contain breaking changes).
 
+## 0.5.0 — 2026-08
+
+### Added
+
+- **`checkMany(requests)`**, on the client and as a standalone
+  export, runs a batch of checks in one resolution scope. The
+  relation-config cache and the node memo span the batch, so the
+  part of the graph the requests have in common is resolved once
+  instead of once per call. A consumer measured a page render
+  making four checks about one object at 862 store statements;
+  the same work in one scope is 21-31.
+
+  Shape follows OpenFGA's BatchCheck: outcomes are
+  `{ allowed, error? }`, a failing check reports its error in its
+  own outcome rather than failing the batch, and only invalid
+  options throw. Answers come back in request order — upstream
+  keys an unordered map on a caller-supplied correlation id, and
+  the array position serves the same purpose without asking for
+  one. Identical requests in a batch coalesce and cost one
+  resolution, which is what upstream gets by de-duplicating on a
+  cache key before dispatch.
+
+  The scope is bounded by the call, so it is safe to use inside a
+  transaction — a tuple written earlier in that transaction is
+  visible to it. That is why this is a shared scope and not a
+  tuple cache.
+
+- **`CheckOptions.maxConcurrentChecks`** (default 50, matching
+  `OPENFGA_MAX_CONCURRENT_CHECKS_PER_BATCH_CHECK`) bounds how many
+  checks of one `checkMany` batch resolve concurrently. It is a
+  separate knob from `maxBreadth`, which bounds the branches
+  within a single check — the same split upstream makes. `check`
+  and `listObjects` ignore it.
+
+### Changed
+
+- **Concurrent routes into the same node now resolve it once.**
+  The node memo published only settled results, so at any
+  `maxBreadth` above 1 the routes overlapped and every one of them
+  re-resolved the shared subtree and re-issued its reads: the
+  resolution DAG walked as a tree, with breadth as the duplication
+  multiplier. A consumer profiling a page render measured one
+  immutable parent edge read 215 times in a single request. A
+  route that arrives while another is still resolving now waits
+  for it.
+
+  Results are unchanged, including for cyclic models. A subtree
+  truncated by a cycle and a subtree that threw are still never
+  shared — both are properties of the route rather than of the
+  node, which is the same line upstream's cached resolver draws
+  for a cycle-detected response.
+
+- **Branches abandoned after a node settles stop querying the
+  store.** A union that found its grant already refused to launch
+  queued branches; the branches already in flight now stop at
+  their next checkpoint instead of walking their subtree. One read
+  per abandoned branch — the one already handed to the store —
+  still lands, because cancellation is not part of the
+  `TupleStore` contract. If you instrument your store, drain its
+  counters before reading them.
+
+### Documentation
+
+- **The README no longer claims that `maxBreadth` never changes the
+  boolean result.** It can, on a model where a cycle reaches an
+  intersection operand: the first failing operand decides and
+  carries its own indeterminacy out, and an enclosing `but not`
+  reads a cycle-flagged denial differently from a plain one. This
+  is upstream's behaviour — OpenFGA's intersection short-circuits
+  the same way and its answer likewise tracks which operand is
+  cheaper — so it is documented rather than "fixed"; making it
+  deterministic would mean granting where OpenFGA denies. The claim
+  was already wrong in 0.4.0. New conformance fixture
+  `intersection-cycle-precedence` pins both directions against a
+  live OpenFGA.
+
+### Notes
+
+- `maxBreadth` keeps its default of 10.
+  `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT` is 10 upstream, and with
+  the change above breadth is no longer a duplication multiplier.
+  What remains true is that breadth buys parallelism only if the
+  store can execute reads concurrently: on a single pooled
+  PostgreSQL connection it buys queueing, and `maxBreadth: 1` is a
+  reasonable setting there.
+
 ## 0.4.0 — 2026-08
 
 ### Breaking changes

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -55,6 +55,7 @@ const allowed = await fga.check({
 | Method | Description |
 |---|---|
 | `check(request)` | Check if a subject has a relation on an object |
+| `checkMany(requests)` | Check several requests in one shared resolution scope; outcomes in request order |
 | `addTuple(request)` | Insert or update a relationship tuple |
 | `removeTuple(request)` | Delete a relationship tuple |
 | `listObjects(objectType, relation, subjectType, subjectId, context?)` | List object IDs the subject can access, in candidate order; `context` is forwarded to each check |
@@ -159,6 +160,8 @@ object as `maxDepth`). The default matches OpenFGA's default
 breadth never changes the boolean result or whether a check
 errors — it caps how many concurrent store reads a single wide
 node can issue (useful to avoid saturating a connection pool).
+(Before 0.5.0 that invariant had one exception, on a model with a
+cycle running through an intersection; see the changelog.)
 When several branches fail, which branch's error surfaces
 depends on completion order — the same nondeterminism OpenFGA
 has. Branches still queued when a node settles are never
@@ -169,6 +172,94 @@ anything else throws `TsfgaError`.
 checked at once — the same knob deliberately, following
 upstream, whose ListObjects worker pool is sized at
 `1 + resolveNodeBreadthLimit`.
+
+**Breadth buys parallelism only if the store can execute
+concurrently.** On a single pooled PostgreSQL connection — the
+normal case for a request-scoped store, and unavoidable for one
+bound to an open transaction — the driver serialises, so raising
+breadth buys queueing rather than parallelism. It no longer costs
+extra *work*: concurrent routes into the same node coalesce onto
+one resolution (see below), so breadth is not a duplication
+multiplier. But if your store cannot resolve reads in parallel,
+the default of 10 gains you little, and `maxBreadth: 1` is a
+reasonable setting. Measure before changing it.
+
+## One resolution per node
+
+The check graph is a DAG, not a tree: the same
+`(object, relation)` is commonly reached by several routes, and a
+deep permission chain funnels every route through the same few
+nodes near the root of the hierarchy.
+
+Each node is resolved once per check, whichever route gets there
+first. A route arriving after another finished reads the settled
+result; a route arriving while another is still resolving waits
+for it rather than starting again. Both are request-scoped: no
+result outlives the call it was computed in, so a check never
+answers from data older than itself.
+
+Two kinds of result are deliberately *not* shared, because they
+are properties of the route rather than of the node: a subtree
+truncated by a cycle, and a subtree that threw. Both are
+re-resolved by the next route, matching what upstream's cached
+resolver does with a cycle-detected response.
+
+## Abandoned branches stop reading
+
+When a union finds its grant, the branches still in flight are no
+longer needed. They stop at their next checkpoint — entering a
+node, a tuple-to-userset lookup, a condition evaluation — instead
+of walking their subtree and querying a store the caller believes
+it is finished with.
+
+The one read that cannot be called back is the one already handed
+to the store: tsfga does not put a cancellation token into
+`TupleStore`. So a store may still see **one** read per abandoned
+branch land after `check()` resolves. If you instrument your
+store, drain its counters before reading them, or you will bill
+one call's reads to the next.
+
+## checkMany
+
+`check()` builds its resolution scope per call, so two checks in
+the same request share nothing and each pays for the whole walk.
+`checkMany` runs a batch of requests in one scope: the
+relation-config cache and the node memo span the batch, so the
+part of the graph they have in common — usually most of it — is
+resolved once.
+
+```ts
+const [canView, canEdit] = await fga.checkMany([
+  { objectType: "document", objectId: docId, relation: "viewer", ...subject },
+  { objectType: "document", objectId: docId, relation: "editor", ...subject },
+]);
+// → [{ allowed: true }, { allowed: false }]
+```
+
+- **Answers are in request order**, one outcome per request.
+  Upstream's BatchCheck keys an unordered map on a
+  caller-supplied correlation id; the array position is the same
+  thing, without asking you for one.
+- **A failing check does not fail the batch.** Its error is
+  reported as `outcome.error` and `allowed` is `false`, matching
+  upstream. `checkMany` itself throws only for invalid options.
+- **Identical requests cost one resolution.** They coalesce at
+  their root node, which is what upstream achieves by
+  de-duplicating a batch on a cache key before dispatching it.
+- **Concurrency is `maxConcurrentChecks`** (default 50, matching
+  `OPENFGA_MAX_CONCURRENT_CHECKS_PER_BATCH_CHECK`). It bounds
+  whole checks; `maxBreadth` bounds the branches inside one. There
+  is no cap on batch size — upstream's
+  `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` guards a server's request
+  handler, and a library holds nobody's socket.
+- **Pass one `context` object**, not an equal copy per request.
+  Requests are grouped into one scope per context by reference
+  identity, because the node memo does not key on the context and
+  requests resolving over different contexts must not share one.
+- **The scope is bounded by the call**, so it is safe inside a
+  transaction: a tuple written earlier in the same transaction is
+  visible to it. This is why a shared scope is offered rather than
+  a tuple cache — a cache would hide that write.
 
 ## listObjects
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -157,16 +157,35 @@ bounded by `maxBreadth` (default 10, via the same options
 object as `maxDepth`). The default matches OpenFGA's default
 `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT` (10); pass
 `maxBreadth: Infinity` to restore unbounded fanout. Bounding
-breadth never changes the boolean result or whether a check
-errors — it caps how many concurrent store reads a single wide
-node can issue (useful to avoid saturating a connection pool).
-(Before 0.5.0 that invariant had one exception, on a model with a
-cycle running through an intersection; see the changelog.)
+breadth caps how many concurrent store reads a single wide node
+can issue, which is useful to avoid saturating a connection pool.
+It almost never changes the answer — see the exception below.
 When several branches fail, which branch's error surfaces
 depends on completion order — the same nondeterminism OpenFGA
 has. Branches still queued when a node settles are never
 started. `maxBreadth` must be an integer >= 1 or `Infinity`;
 anything else throws `TsfgaError`.
+
+**The exception: a cycle reaching an intersection operand.** An
+intersection denies as soon as one operand fails to hold, and two
+kinds of operand fail to hold — a definitive `false` and a branch
+truncated by a cycle. The first to arrive decides, and it carries
+its own indeterminacy out with the denial. One level up that
+matters: on the subtract side of a `but not`, a cycle denies and a
+plain `false` does not. So on a model where a cycle reaches an
+intersection operand, which operand wins the race can change the
+final answer, and breadth is what decides whether the operands
+race at all.
+
+This is upstream's behaviour, not a tsfga quirk: OpenFGA's
+intersection short-circuits on the first `CycleDetected ||
+!Allowed` outcome and propagates that outcome's flag, so its answer
+tracks which operand is cheaper to resolve and its own concurrency
+limit has the same exposure. Preferring the definitive `false`
+would be deterministic and would diverge from OpenFGA — granting
+where it denies. Matching upstream means racing as it races.
+`tests/conformance/intersection-cycle-precedence.test.ts` pins both
+directions against a live OpenFGA.
 
 `maxBreadth` also bounds how many `listObjects` candidates are
 checked at once — the same knob deliberately, following

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsfga/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "author": "Lemuel Roberto Bonifacio <code@lemuelroberto.online>",
   "description": "OpenFGA-compatible relationship-based access control for TypeScript",

--- a/packages/core/src/check-many.ts
+++ b/packages/core/src/check-many.ts
@@ -1,0 +1,149 @@
+import { type CheckScope, createCheckScope, runCheck } from "./check.ts";
+import { TsfgaError } from "./errors.ts";
+import type { TupleStore } from "./store-interface.ts";
+import type { CheckOptions, CheckRequest } from "./types.ts";
+
+/**
+ * One check's answer inside a batch.
+ *
+ * A failing check does not fail the batch: the error is reported
+ * against the check that produced it and the rest still answer.
+ * That is upstream's shape — `BatchCheckOutcome{Allowed, Err}`,
+ * whose worker records the error and returns nil so the pool is
+ * never cancelled (`pkg/server/commands/batch_check_command.go`).
+ *
+ * `allowed` is always `false` when `error` is set. An unresolved
+ * check is not a grant.
+ */
+export interface CheckOutcome {
+  readonly allowed: boolean;
+  /** Whatever `check` would have thrown, or undefined on success. */
+  readonly error?: unknown;
+}
+
+/** Stands in for `undefined` as a context-group key. */
+const NO_CONTEXT = Symbol("no context");
+
+/**
+ * Check several requests, sharing one resolution scope.
+ *
+ * A `check()` call builds its scope — the relation-config cache and
+ * the node memo — from scratch, so two checks about the same object
+ * in the same request share nothing and each pays for the full
+ * walk. A consumer measured one page render making four checks
+ * about one object, asking 29 distinct questions between them and
+ * paying for all four walks: 862 store statements against 21-31 for
+ * the same work in one scope.
+ *
+ * A scope is the right unit for this and a cache is not. Tuple
+ * reads have to stay inside the caller's transaction, so a grant
+ * written earlier in the same request must be visible to a later
+ * check; a batch-scoped memo cannot outlive the transaction it was
+ * built in, and a process-wide cache of tuples would.
+ *
+ * Requests are answered in request order. Upstream returns an
+ * unordered map keyed by a caller-supplied correlation id; the
+ * position in the array is tsfga's correlation id, which is
+ * stricter and needs nothing from the caller.
+ *
+ * Identical requests in one batch cost one resolution, because the
+ * shared scope coalesces them at their root node — the same
+ * de-duplication upstream does explicitly before dispatching a
+ * batch, arrived at from the algorithm rather than from a key.
+ * Requests carrying contextual tuples are the exception: those
+ * resolve over a graph of their own and share nothing, which is the
+ * conservative direction.
+ *
+ * Concurrency is bounded by `maxConcurrentChecks` (default 50,
+ * matching `OPENFGA_MAX_CONCURRENT_CHECKS_PER_BATCH_CHECK`), which
+ * is a separate knob from `maxBreadth`: this bounds whole checks,
+ * that bounds the branches of one node. There is no cap on the size
+ * of a batch — upstream's `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` is a
+ * server-side request guard, and a library holds nobody's socket.
+ *
+ * @throws TsfgaError only for invalid options. A check that fails
+ *   is reported in its own outcome, never thrown.
+ */
+export async function checkMany(
+  store: TupleStore,
+  requests: readonly CheckRequest[],
+  options: CheckOptions = {},
+): Promise<CheckOutcome[]> {
+  const maxConcurrentChecks = options.maxConcurrentChecks ?? 50;
+  // Same rule as maxBreadth: the negated comparison rejects NaN,
+  // and a fraction would admit one worker more than it says.
+  if (
+    !(maxConcurrentChecks >= 1) ||
+    (maxConcurrentChecks !== Number.POSITIVE_INFINITY &&
+      !Number.isInteger(maxConcurrentChecks))
+  ) {
+    throw new TsfgaError(
+      "maxConcurrentChecks must be a positive integer or Infinity, " +
+        `got ${maxConcurrentChecks}`,
+    );
+  }
+
+  // One scope per distinct CEL context. The memo keys on subject
+  // and node but not on the context, and the config cache keys on
+  // nothing, so requests may only share a scope if they resolve
+  // over the same context.
+  //
+  // Grouped by *reference identity*, not by structural equality:
+  // sound with no assumptions about what a context may contain
+  // (a `Date`, a class instance, a cyclic object — none of which a
+  // canonical serialisation handles). The cost is that a caller who
+  // rebuilds an equal context per request gets no sharing, which is
+  // why the docs say to pass one object.
+  //
+  // Built eagerly, before any request is looked at, so the rest of
+  // the option validation reaches the caller even when the batch is
+  // empty. The config cache is context-independent, so the groups
+  // share the one this creates: `createCheckScope` will not re-wrap
+  // a store that is already caching.
+  const first = createCheckScope(store, options);
+  const scopes = new Map<unknown, CheckScope>();
+  const scopeFor = (request: CheckRequest): CheckScope => {
+    const key = request.context ?? NO_CONTEXT;
+    let scope = scopes.get(key);
+    if (!scope) {
+      scope =
+        scopes.size === 0 ? first : createCheckScope(first.store, options);
+      scopes.set(key, scope);
+    }
+    return scope;
+  };
+
+  const outcomes = new Array<CheckOutcome>(requests.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    for (let index = next++; index < requests.length; index = next++) {
+      const request = requests[index];
+      if (!request) {
+        // Only reachable from JS passing a sparse array, which the
+        // type forbids. Still answer the slot: a hole in a
+        // `CheckOutcome[]` is a worse thing to hand back than an
+        // outcome saying there was nothing to check.
+        outcomes[index] = {
+          allowed: false,
+          error: new TsfgaError(`no check request at index ${index}`),
+        };
+        continue;
+      }
+      try {
+        outcomes[index] = {
+          allowed: await runCheck(scopeFor(request), request),
+        };
+      } catch (error) {
+        outcomes[index] = { allowed: false, error };
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(maxConcurrentChecks, requests.length) },
+      worker,
+    ),
+  );
+  return outcomes;
+}

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -226,6 +226,12 @@ export async function check(
  * Contextual tuples are the other half of that constraint and
  * `runCheck` handles them itself, below.
  *
+ * It doubles as the resolution context every node is handed, which
+ * is why it is threaded down instead of being unpacked into
+ * positional parameters: `checkNode` would otherwise carry a
+ * parameter per shared field, and every recursive call site would
+ * have to repeat them in the right order.
+ *
  * Internal. Not re-exported from `index.ts`.
  */
 export interface CheckScope {
@@ -268,8 +274,7 @@ export async function runCheck(
   scope: CheckScope,
   request: CheckRequest,
 ): Promise<boolean> {
-  let store = scope.store;
-  let memo = scope.memo;
+  let resolution = scope;
 
   // Wrap store with contextual tuples for the whole request.
   // Contextual tuples must pass the same validation as addTuple.
@@ -287,23 +292,18 @@ export async function runCheck(
         throw validation.reason;
       }
     }
-    store = new ContextualTupleStore(scope.store, request.contextualTuples);
     // These tuples exist for this request only, so results resolved
     // over them are not shareable — and results already in the
     // scope's memo were resolved over a graph missing them. Neither
     // direction is safe, so this request memoizes on its own.
-    memo = new Map();
+    resolution = {
+      ...scope,
+      store: new ContextualTupleStore(scope.store, request.contextualTuples),
+      memo: new Map(),
+    };
   }
 
-  const result = await checkNode(
-    store,
-    request,
-    scope.maxDepth,
-    scope.maxBreadth,
-    0,
-    new Set(),
-    memo,
-  );
+  const result = await checkNode(resolution, request, 0, new Set());
   // The indeterminacy flag is internal; a cycle at the root is an
   // ordinary deny to the caller, as it is on OpenFGA's wire.
   return result.allowed;
@@ -317,14 +317,12 @@ export async function runCheck(
  * forever.
  */
 async function checkNode(
-  store: TupleStore,
+  scope: CheckScope,
   request: CheckRequest,
-  maxDepth: number,
-  maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
-  memo: NodeMemo,
 ): Promise<CheckResult> {
+  const { maxDepth, memo } = scope;
   // `depth` counts dispatches already made, so the budget is spent
   // once it reaches maxDepth — OpenFGA errors on
   // `Depth == maxResolutionDepth`, before resolving the node.
@@ -357,15 +355,7 @@ async function checkNode(
   const visited = new Set(path);
   visited.add(key);
 
-  const result = await resolveNode(
-    store,
-    request,
-    maxDepth,
-    maxBreadth,
-    depth,
-    visited,
-    memo,
-  );
+  const result = await resolveNode(scope, request, depth, visited);
 
   // Only path-independent results are publishable.
   //
@@ -401,14 +391,12 @@ async function checkNode(
  * lookup and the memo write bracket a single call.
  */
 async function resolveNode(
-  store: TupleStore,
+  scope: CheckScope,
   request: CheckRequest,
-  maxDepth: number,
-  maxBreadth: number,
   depth: number,
   visited: ReadonlySet<string>,
-  memo: NodeMemo,
 ): Promise<CheckResult> {
+  const store = scope.store;
   // Fetch relation config once for use across all steps — and
   // before the tuple reads, which are gated on it.
   //
@@ -434,28 +422,8 @@ async function resolveNode(
   // Base resolution: intersection replaces steps 1-5 when present
   const resolveBase = (): Promise<CheckResult> =>
     config?.intersection
-      ? checkIntersection(
-          store,
-          request,
-          config,
-          reads,
-          maxDepth,
-          maxBreadth,
-          depth,
-          visited,
-          memo,
-        )
-      : checkBase(
-          store,
-          request,
-          config,
-          reads,
-          maxDepth,
-          maxBreadth,
-          depth,
-          visited,
-          memo,
-        );
+      ? checkIntersection(scope, request, config, reads, depth, visited)
+      : checkBase(scope, request, config, reads, depth, visited);
 
   // Exclusion applies on top of the base result — including on top
   // of intersection results. A definitive deny short-circuits past
@@ -478,15 +446,7 @@ async function resolveNode(
       resolveBase(),
       // Same object, a rewrite of it — no depth cost (upstream
       // builds the subtract branch on the unchanged request).
-      checkNode(
-        store,
-        { ...request, relation: excludedBy },
-        maxDepth,
-        maxBreadth,
-        depth,
-        visited,
-        memo,
-      ),
+      checkNode(scope, { ...request, relation: excludedBy }, depth, visited),
     ]);
     if (
       exclusionResult.status === "fulfilled" &&
@@ -680,16 +640,14 @@ async function evaluateCondition(
  * Base check: steps 1-5 without exclusion or intersection handling.
  */
 async function checkBase(
-  store: TupleStore,
+  scope: CheckScope,
   request: CheckRequest,
   config: RelationConfig | null,
   reads: Promise<CheckTuples>,
-  maxDepth: number,
-  maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
-  memo: NodeMemo,
 ): Promise<CheckResult> {
+  const { store, maxBreadth } = scope;
   const {
     direct: directTuple,
     wildcard: wildcardTuple,
@@ -731,7 +689,7 @@ async function checkBase(
         return DENIED;
       }
       return checkNode(
-        store,
+        scope,
         {
           objectType: userset.subjectType,
           objectId: userset.subjectId,
@@ -740,11 +698,8 @@ async function checkBase(
           subjectId: request.subjectId,
           context: request.context,
         },
-        maxDepth,
-        maxBreadth,
         depth + 1,
         path,
-        memo,
       );
     });
   }
@@ -756,13 +711,10 @@ async function checkBase(
     for (const impliedRelation of config.impliedBy) {
       handlers.push(() =>
         checkNode(
-          store,
+          scope,
           { ...request, relation: impliedRelation },
-          maxDepth,
-          maxBreadth,
           depth,
           path,
-          memo,
         ),
       );
     }
@@ -772,15 +724,7 @@ async function checkBase(
   if (config?.computedUserset) {
     const computedUserset = config.computedUserset;
     handlers.push(() =>
-      checkNode(
-        store,
-        { ...request, relation: computedUserset },
-        maxDepth,
-        maxBreadth,
-        depth,
-        path,
-        memo,
-      ),
+      checkNode(scope, { ...request, relation: computedUserset }, depth, path),
     );
   }
 
@@ -807,7 +751,7 @@ async function checkBase(
         for (const linked of linkedTuples) {
           ttuHandlers.push(() =>
             checkNode(
-              store,
+              scope,
               {
                 objectType: linked.subjectType,
                 objectId: linked.subjectId,
@@ -816,11 +760,8 @@ async function checkBase(
                 subjectId: request.subjectId,
                 context: request.context,
               },
-              maxDepth,
-              maxBreadth,
               depth + 1,
               path,
-              memo,
             ),
           );
         }
@@ -837,16 +778,14 @@ async function checkBase(
  * Intersection check: ALL operands must be true.
  */
 async function checkIntersection(
-  store: TupleStore,
+  scope: CheckScope,
   request: CheckRequest,
   config: RelationConfig,
   reads: Promise<CheckTuples>,
-  maxDepth: number,
-  maxBreadth: number,
   depth: number,
   path: ReadonlySet<string>,
-  memo: NodeMemo,
 ): Promise<CheckResult> {
+  const { store, maxBreadth } = scope;
   const operands = config.intersection;
   // An intersection with no operands would resolve vacuously true,
   // granting access to every subject on a malformed config.
@@ -864,29 +803,16 @@ async function checkIntersection(
   for (const operand of operands) {
     if (operand.type === "direct") {
       handlers.push(() =>
-        checkBase(
-          store,
-          request,
-          config,
-          reads,
-          maxDepth,
-          maxBreadth,
-          depth,
-          path,
-          memo,
-        ),
+        checkBase(scope, request, config, reads, depth, path),
       );
     } else if (operand.type === "computedUserset") {
       // Same object, no depth cost — as with the other rewrites.
       handlers.push(() =>
         checkNode(
-          store,
+          scope,
           { ...request, relation: operand.relation },
-          maxDepth,
-          maxBreadth,
           depth,
           path,
-          memo,
         ),
       );
     } else {
@@ -901,7 +827,7 @@ async function checkIntersection(
         for (const linked of linkedTuples) {
           ttuHandlers.push(() =>
             checkNode(
-              store,
+              scope,
               {
                 objectType: linked.subjectType,
                 objectId: linked.subjectId,
@@ -910,11 +836,8 @@ async function checkIntersection(
                 subjectId: request.subjectId,
                 context: request.context,
               },
-              maxDepth,
-              maxBreadth,
               depth + 1,
               path,
-              memo,
             ),
           );
         }

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -111,10 +111,11 @@ interface MemoEntry {
  * key merely over-eager while making the memo *wrong*.
  */
 type MemoMap<V> = Map<string, V>;
-type NodeMemo = MemoMap<MemoMap<MemoMap<MemoMap<MemoMap<MemoEntry>>>>>;
+type NodeMap<V> = MemoMap<MemoMap<MemoMap<MemoMap<MemoMap<V>>>>>;
+type NodeMemo = NodeMap<MemoEntry>;
 
-function memoGet(memo: NodeMemo, request: CheckRequest): MemoEntry | undefined {
-  return memo
+function nodeGet<V>(map: NodeMap<V>, request: CheckRequest): V | undefined {
+  return map
     .get(request.subjectType)
     ?.get(request.subjectId)
     ?.get(request.objectType)
@@ -131,16 +132,107 @@ function memoLevel<V>(map: MemoMap<MemoMap<V>>, key: string): MemoMap<V> {
   return level;
 }
 
-function memoSet(
-  memo: NodeMemo,
-  request: CheckRequest,
-  entry: MemoEntry,
-): void {
-  const bySubjectId = memoLevel(memo, request.subjectType);
+function nodeSet<V>(map: NodeMap<V>, request: CheckRequest, value: V): void {
+  const bySubjectId = memoLevel(map, request.subjectType);
   const byObjectType = memoLevel(bySubjectId, request.subjectId);
   const byObjectId = memoLevel(byObjectType, request.objectType);
   const byRelation = memoLevel(byObjectId, request.objectId);
-  byRelation.set(request.relation, entry);
+  byRelation.set(request.relation, value);
+}
+
+/**
+ * Drop a node's entry, but only while it is still the stored one —
+ * a later resolution may already have replaced it
+ * (`caching-store.ts` evicts on the same rule).
+ */
+function nodeDelete<V>(map: NodeMap<V>, request: CheckRequest, value: V): void {
+  if (nodeGet(map, request) === value) {
+    map
+      .get(request.subjectType)
+      ?.get(request.subjectId)
+      ?.get(request.objectType)
+      ?.get(request.objectId)
+      ?.delete(request.relation);
+  }
+}
+
+/**
+ * A node whose resolution has started but not settled, and what
+ * its subtree is currently blocked on.
+ *
+ * The settled memo only helps a route that arrives *after* another
+ * route finished. At any breadth above 1 the routes overlap
+ * instead, so without this every concurrent route into a shared
+ * node re-resolves it and re-issues its reads: the DAG explored as
+ * a tree, with breadth as the duplication multiplier.
+ */
+interface InflightEntry {
+  readonly promise: Promise<CheckResult>;
+  /** The depth the resolution started at; gates reuse, as in the memo. */
+  readonly depth: number;
+  readonly waits: WaitNode;
+}
+
+/**
+ * One node's edge set in the wait graph: the in-flight entries its
+ * subtree is currently awaiting.
+ *
+ * Counted rather than a plain set, because two branches of the same
+ * node can await the same entry and the first to finish must not
+ * erase the second's edge — a missing edge is a missed deadlock,
+ * which is the one failure mode with no recovery.
+ */
+interface WaitNode {
+  readonly waitingOn: Map<InflightEntry, number>;
+}
+
+function addWait(node: WaitNode, entry: InflightEntry): void {
+  node.waitingOn.set(entry, (node.waitingOn.get(entry) ?? 0) + 1);
+}
+
+function removeWait(node: WaitNode, entry: InflightEntry): void {
+  const count = node.waitingOn.get(entry) ?? 0;
+  if (count > 1) {
+    node.waitingOn.set(entry, count - 1);
+  } else {
+    node.waitingOn.delete(entry);
+  }
+}
+
+/**
+ * Would awaiting `entry` close a cycle in the wait graph — i.e. is
+ * `waiter` already reachable from it?
+ *
+ * This is the whole reason coalescing is safe here when the obvious
+ * version is not. Two sibling branches resolving mutually recursive
+ * relations each reach the other's node: neither is on the other's
+ * *path*, so the cycle guard says nothing, and each would await an
+ * entry that can only settle once the other does. Adding an edge
+ * only when it keeps the graph acyclic makes that unreachable, and
+ * an acyclic wait graph cannot deadlock.
+ *
+ * The test and the edge insertion happen in one synchronous stretch
+ * — nothing awaits between them — so there is no interleaving in
+ * which two waiters each see the other's absence.
+ */
+function wouldDeadlock(entry: InflightEntry, waiter: WaitNode | null): boolean {
+  if (!waiter) {
+    // A root check registers no wait record: it is nobody's
+    // callee, so nothing can be blocked behind it.
+    return false;
+  }
+  const seen = new Set<WaitNode>();
+  const stack: WaitNode[] = [entry.waits];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || seen.has(node)) continue;
+    if (node === waiter) return true;
+    seen.add(node);
+    for (const blocker of node.waitingOn.keys()) {
+      stack.push(blocker.waits);
+    }
+  }
+  return false;
 }
 
 /**
@@ -239,7 +331,32 @@ export interface CheckScope {
   readonly maxDepth: number;
   readonly maxBreadth: number;
   readonly memo: NodeMemo;
+  readonly inflight: NodeMap<InflightEntry>;
 }
+
+/**
+ * What one call inherits from the call that made it, as opposed to
+ * from the request (`CheckScope`) or from the node itself (request,
+ * depth, path).
+ *
+ * It is an object rather than a parameter so that adding a concern
+ * threaded through the whole recursion does not add a positional
+ * parameter to `checkNode`, `resolveNode`, `checkBase` and
+ * `checkIntersection` at once, plus one to every recursive call
+ * site.
+ */
+interface Frame {
+  /**
+   * The wait record of the nearest enclosing node — null at the
+   * root of a check. A blocked child records the block here,
+   * because the thing that is actually stuck is the enclosing
+   * node's resolution.
+   */
+  readonly waits: WaitNode | null;
+}
+
+/** The frame a check starts from: nothing is enclosing it. */
+const ROOT_FRAME: Frame = { waits: null };
 
 export function createCheckScope(
   store: TupleStore,
@@ -266,6 +383,7 @@ export function createCheckScope(
     maxDepth: options.maxDepth ?? 25,
     maxBreadth,
     memo: new Map(),
+    inflight: new Map(),
   };
 }
 
@@ -300,10 +418,11 @@ export async function runCheck(
       ...scope,
       store: new ContextualTupleStore(scope.store, request.contextualTuples),
       memo: new Map(),
+      inflight: new Map(),
     };
   }
 
-  const result = await checkNode(resolution, request, 0, new Set());
+  const result = await checkNode(resolution, request, 0, new Set(), ROOT_FRAME);
   // The indeterminacy flag is internal; a cycle at the root is an
   // ordinary deny to the caller, as it is on OpenFGA's wire.
   return result.allowed;
@@ -321,6 +440,7 @@ async function checkNode(
   request: CheckRequest,
   depth: number,
   path: ReadonlySet<string>,
+  frame: Frame,
 ): Promise<CheckResult> {
   const { maxDepth, memo } = scope;
   // `depth` counts dispatches already made, so the budget is spent
@@ -347,15 +467,109 @@ async function checkNode(
   // Deeper is not safe: reusing it there could answer where a fresh
   // resolution would have thrown DepthExceededError. Recording the
   // greatest depth seen therefore widens the range of reuse.
-  const memoized = memoGet(memo, request);
+  let memoized = nodeGet(memo, request);
   if (memoized && depth <= memoized.depth) {
     return memoized.result;
+  }
+
+  // Nothing settled: is this node already being resolved by another
+  // route? Coalescing onto it is what keeps the DAG from being
+  // walked as a tree at breadth > 1, and the same depth gate applies
+  // for the same reason.
+  //
+  // Three outcomes send this call on to resolve the node itself.
+  // Each duplicates work in a case that is rare, and none of them
+  // can be wrong:
+  //
+  // - `wouldDeadlock` refuses the wait. The fresh resolution runs
+  //   with *this* path, so the cycle guard truncates it and it
+  //   terminates; each such fallback resolves with a strictly larger
+  //   path, and the path is bounded by a finite relation set.
+  // - The entry rejected. An error is not path-independent — a
+  //   sibling truncated by a cycle can hide an error on one route
+  //   and not on another, and the combinator drops the cycle flag
+  //   when it rejects — so an error is no more adoptable than it is
+  //   memoizable. It also covers depth exhaustion, where a shallower
+  //   waiter must be free to succeed where the entry failed.
+  // - The entry settled cycle-flagged, which is path-dependent by
+  //   definition. The memo refuses to publish those; this refuses to
+  //   consume them, which is the same rule from the other side.
+  //   (Upstream's cached resolver draws the same line:
+  //   "when the response indicates cycle detected ... we don't save
+  //   the result", `internal/graph/cached_resolver.go`.)
+  const pending = nodeGet(scope.inflight, request);
+  if (
+    pending &&
+    depth <= pending.depth &&
+    !wouldDeadlock(pending, frame.waits)
+  ) {
+    const waiter = frame.waits;
+    if (waiter) addWait(waiter, pending);
+    let coalesced: CheckResult | null = null;
+    try {
+      coalesced = await pending.promise;
+    } catch {
+      // Resolve it ourselves; see above.
+    } finally {
+      if (waiter) removeWait(waiter, pending);
+    }
+    if (coalesced && !coalesced.cycleDetected) {
+      return coalesced;
+    }
+    // Time passed while waiting, and a third route may have settled
+    // the node in it. Re-reading also keeps the "greatest depth
+    // wins" comparison below honest.
+    memoized = nodeGet(memo, request);
+    if (memoized && depth <= memoized.depth) {
+      return memoized.result;
+    }
   }
 
   const visited = new Set(path);
   visited.add(key);
 
-  const result = await resolveNode(scope, request, depth, visited);
+  // Publish only the first resolution of a node. A later one is a
+  // fallback from the list above, so it is running with a path that
+  // already truncated something; its answer is this route's answer
+  // and nobody else should coalesce onto it.
+  //
+  // An unpublished resolution is also *transparent* in the wait
+  // graph: it keeps the caller's wait record instead of opening one
+  // of its own, so a block inside it is attributed to the nearest
+  // enclosing published node. Give it its own record and that node
+  // looks idle while its subtree is blocked, which is exactly the
+  // edge a deadlock hides behind.
+  const waits: WaitNode | null = nodeGet(scope.inflight, request)
+    ? null
+    : { waitingOn: new Map() };
+  const resolution = resolveNode(
+    scope,
+    request,
+    depth,
+    visited,
+    waits ? { waits } : frame,
+  );
+
+  if (waits) {
+    const entry: InflightEntry = { promise: resolution, depth, waits };
+    nodeSet(scope.inflight, request, entry);
+    // A node is blocked on the children it resolves itself exactly
+    // as much as on the ones it coalesced onto, so both kinds of
+    // dependency are edges. Recording only the coalesced ones would
+    // leave a node looking idle while it awaits its own subtree,
+    // and a later waiter would happily close the loop through it.
+    const caller = frame.waits;
+    if (caller) addWait(caller, entry);
+    const retire = () => {
+      nodeDelete(scope.inflight, request, entry);
+      if (caller) removeWait(caller, entry);
+    };
+    // The derived promise consumes the rejection on its own copy;
+    // the `await` below still sees it.
+    resolution.then(retire, retire);
+  }
+
+  const result = await resolution;
 
   // Only path-independent results are publishable.
   //
@@ -377,10 +591,8 @@ async function checkNode(
   // A throw is simply never recorded, which is also how a
   // depth-exhausted subtree stays out: nothing is written, so the
   // same node resolves normally if it is reached again shallower.
-  // Nothing in-flight is ever published, so unlike the store cache
-  // there is no promise to evict and no rejection to swallow.
   if (!result.cycleDetected && (!memoized || depth > memoized.depth)) {
-    memoSet(memo, request, { result, depth });
+    nodeSet(memo, request, { result, depth });
   }
   return result;
 }
@@ -395,6 +607,7 @@ async function resolveNode(
   request: CheckRequest,
   depth: number,
   visited: ReadonlySet<string>,
+  frame: Frame,
 ): Promise<CheckResult> {
   const store = scope.store;
   // Fetch relation config once for use across all steps — and
@@ -422,8 +635,8 @@ async function resolveNode(
   // Base resolution: intersection replaces steps 1-5 when present
   const resolveBase = (): Promise<CheckResult> =>
     config?.intersection
-      ? checkIntersection(scope, request, config, reads, depth, visited)
-      : checkBase(scope, request, config, reads, depth, visited);
+      ? checkIntersection(scope, request, config, reads, depth, visited, frame)
+      : checkBase(scope, request, config, reads, depth, visited, frame);
 
   // Exclusion applies on top of the base result — including on top
   // of intersection results. A definitive deny short-circuits past
@@ -446,7 +659,13 @@ async function resolveNode(
       resolveBase(),
       // Same object, a rewrite of it — no depth cost (upstream
       // builds the subtract branch on the unchanged request).
-      checkNode(scope, { ...request, relation: excludedBy }, depth, visited),
+      checkNode(
+        scope,
+        { ...request, relation: excludedBy },
+        depth,
+        visited,
+        frame,
+      ),
     ]);
     if (
       exclusionResult.status === "fulfilled" &&
@@ -646,6 +865,7 @@ async function checkBase(
   reads: Promise<CheckTuples>,
   depth: number,
   path: ReadonlySet<string>,
+  frame: Frame,
 ): Promise<CheckResult> {
   const { store, maxBreadth } = scope;
   const {
@@ -700,6 +920,7 @@ async function checkBase(
         },
         depth + 1,
         path,
+        frame,
       );
     });
   }
@@ -715,6 +936,7 @@ async function checkBase(
           { ...request, relation: impliedRelation },
           depth,
           path,
+          frame,
         ),
       );
     }
@@ -724,7 +946,13 @@ async function checkBase(
   if (config?.computedUserset) {
     const computedUserset = config.computedUserset;
     handlers.push(() =>
-      checkNode(scope, { ...request, relation: computedUserset }, depth, path),
+      checkNode(
+        scope,
+        { ...request, relation: computedUserset },
+        depth,
+        path,
+        frame,
+      ),
     );
   }
 
@@ -762,6 +990,7 @@ async function checkBase(
               },
               depth + 1,
               path,
+              frame,
             ),
           );
         }
@@ -784,6 +1013,7 @@ async function checkIntersection(
   reads: Promise<CheckTuples>,
   depth: number,
   path: ReadonlySet<string>,
+  frame: Frame,
 ): Promise<CheckResult> {
   const { store, maxBreadth } = scope;
   const operands = config.intersection;
@@ -803,7 +1033,7 @@ async function checkIntersection(
   for (const operand of operands) {
     if (operand.type === "direct") {
       handlers.push(() =>
-        checkBase(scope, request, config, reads, depth, path),
+        checkBase(scope, request, config, reads, depth, path, frame),
       );
     } else if (operand.type === "computedUserset") {
       // Same object, no depth cost — as with the other rewrites.
@@ -813,6 +1043,7 @@ async function checkIntersection(
           { ...request, relation: operand.relation },
           depth,
           path,
+          frame,
         ),
       );
     } else {
@@ -838,6 +1069,7 @@ async function checkIntersection(
               },
               depth + 1,
               path,
+              frame,
             ),
           );
         }

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -447,8 +447,12 @@ export function createCheckScope(
 
   return {
     // Cache for relation configs and condition definitions: static
-    // per model, but read at every node.
-    store: new CachingTupleStore(store),
+    // per model, but read at every node. A store that already
+    // caches is passed through: `checkMany` builds a scope per
+    // context group and they share one config cache, which a second
+    // wrapper would silently split in two.
+    store:
+      store instanceof CachingTupleStore ? store : new CachingTupleStore(store),
     maxDepth: options.maxDepth ?? 25,
     maxBreadth,
     memo: new Map(),

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -75,6 +75,31 @@ export const UNION_REDUCER: Reducer = {
  * Intersection: a cycle is as fatal as a plain `false`, since an
  * operand that could not be resolved cannot be shown to hold. The
  * deciding operand's flag rides out with the denial.
+ *
+ * **The first failing operand decides, whichever kind it is.** The
+ * two kinds are not interchangeable — the flag reaches an
+ * enclosing exclusion, where a cycle denies and a plain `false`
+ * does not — so which operand wins the race is visible in the
+ * final answer. That is upstream's behaviour
+ * (`internal/graph/check.go`, `intersection`: the outcome loop
+ * short-circuits on `CycleDetected || !Allowed` and propagates
+ * that outcome's flag), and matching it means racing as it races.
+ *
+ * Preferring the definitive `false` looks better and is wrong.
+ * Upstream's answer tracks which operand is cheaper to resolve: a
+ * cheap definitive operand and a cheap cycle give different
+ * results, both reproducible. Always choosing the definitive one
+ * matches upstream only when it happens to be the cheap one, and
+ * diverges — fail-open, granting where OpenFGA denies — when it is
+ * not. That was tried, and
+ * `tests/conformance/intersection-cycle-precedence.test.ts` is the
+ * fixture that caught it against the running container.
+ *
+ * The cost is that `maxBreadth` can change the boolean answer on a
+ * model where a cycle reaches an intersection operand, since
+ * breadth is what decides whether the operands race at all.
+ * Upstream has the same exposure through its own concurrency
+ * limit. Documented in the README rather than smoothed over.
  */
 export const INTERSECTION_REDUCER: Reducer = {
   initial: GRANTED,

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -353,10 +353,79 @@ interface Frame {
    * node's resolution.
    */
   readonly waits: WaitNode | null;
+  /** Whether anyone is still interested in this call's answer. */
+  readonly branch: Branch;
 }
 
 /** The frame a check starts from: nothing is enclosing it. */
-const ROOT_FRAME: Frame = { waits: null };
+function rootFrame(): Frame {
+  return { waits: null, branch: new Branch(null) };
+}
+
+/**
+ * One branch of a set operator, and whether its answer is still
+ * wanted.
+ *
+ * A union that has found its grant stops *launching* queued
+ * branches, but the branches already in flight used to keep
+ * walking: a subtree resolving reads nobody will ever look at,
+ * against a store the caller believes it has finished with. On a
+ * pooled connection that also holds the connection past the end of
+ * the request that borrowed it.
+ *
+ * Abandonment is cooperative rather than an `AbortSignal` threaded
+ * into `TupleStore`. It costs no change to the store contract and
+ * no work for adapter authors; what it cannot do is call back a
+ * read already handed to the store. So the read in flight when a
+ * branch is abandoned still completes — everything after it does
+ * not.
+ *
+ * Nesting is by parent link: abandoning a branch abandons every
+ * branch opened underneath it, without having to find them.
+ */
+class Branch {
+  private flag = false;
+
+  constructor(private readonly parent: Branch | null) {}
+
+  abandon(): void {
+    this.flag = true;
+  }
+
+  get abandoned(): boolean {
+    for (let branch: Branch | null = this; branch; branch = branch.parent) {
+      if (branch.flag) return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Thrown by an abandoned branch instead of an answer.
+ *
+ * It is never seen by a caller: a branch is abandoned only by a
+ * combinator that has already settled and therefore ignores what
+ * its branches do next, and the root branch of a check is never
+ * abandoned at all. The one other reader is a coalesced waiter,
+ * whose fallback treats every rejection alike.
+ *
+ * Deliberately not a `TsfgaError`: it is not part of the error
+ * surface and must never be mistaken for one.
+ */
+class BranchAbandoned extends Error {
+  constructor() {
+    super("check branch abandoned after the result was decided");
+    this.name = "BranchAbandoned";
+  }
+}
+
+/**
+ * One branch of a set operator, as handed to the combinator. It
+ * receives the branch it runs in so that anything it dispatches can
+ * be abandoned with it; handlers that reach no further than a
+ * condition evaluation ignore the argument.
+ */
+type Handler = (branch: Branch) => Promise<CheckResult>;
 
 export function createCheckScope(
   store: TupleStore,
@@ -422,7 +491,13 @@ export async function runCheck(
     };
   }
 
-  const result = await checkNode(resolution, request, 0, new Set(), ROOT_FRAME);
+  const result = await checkNode(
+    resolution,
+    request,
+    0,
+    new Set(),
+    rootFrame(),
+  );
   // The indeterminacy flag is internal; a cycle at the root is an
   // ordinary deny to the caller, as it is on OpenFGA's wire.
   return result.allowed;
@@ -547,7 +622,7 @@ async function checkNode(
     request,
     depth,
     visited,
-    waits ? { waits } : frame,
+    waits ? { waits, branch: frame.branch } : frame,
   );
 
   if (waits) {
@@ -610,6 +685,12 @@ async function resolveNode(
   frame: Frame,
 ): Promise<CheckResult> {
   const store = scope.store;
+  // Nothing below this line is worth a round trip if the answer
+  // this branch was going to contribute is already discarded.
+  if (frame.branch.abandoned) {
+    throw new BranchAbandoned();
+  }
+
   // Fetch relation config once for use across all steps — and
   // before the tuple reads, which are gated on it.
   //
@@ -884,7 +965,7 @@ async function checkBase(
   }
 
   // Collect all sub-check handlers for concurrent resolution
-  const handlers: Array<() => Promise<CheckResult>> = [];
+  const handlers: Handler[] = [];
 
   // Conditioned direct/wildcard hits race as union branches so
   // their condition evaluation (a possible condition-definition
@@ -904,7 +985,10 @@ async function checkBase(
   for (const userset of usersetTuples) {
     if (!userset.subjectRelation) continue;
     const relation = userset.subjectRelation;
-    handlers.push(async () => {
+    handlers.push(async (branch) => {
+      // The condition can cost a condition-definition fetch, so it
+      // is behind the same gate as a node read.
+      if (branch.abandoned) throw new BranchAbandoned();
       if (!(await evaluateTupleCondition(store, userset, request.context))) {
         return DENIED;
       }
@@ -920,7 +1004,7 @@ async function checkBase(
         },
         depth + 1,
         path,
-        frame,
+        { waits: frame.waits, branch },
       );
     });
   }
@@ -930,13 +1014,16 @@ async function checkBase(
   // on `check`.
   if (config?.impliedBy) {
     for (const impliedRelation of config.impliedBy) {
-      handlers.push(() =>
+      handlers.push((branch) =>
         checkNode(
           scope,
           { ...request, relation: impliedRelation },
           depth,
           path,
-          frame,
+          {
+            waits: frame.waits,
+            branch,
+          },
         ),
       );
     }
@@ -945,14 +1032,11 @@ async function checkBase(
   // Step 4: Computed userset handler. Same object, no depth cost.
   if (config?.computedUserset) {
     const computedUserset = config.computedUserset;
-    handlers.push(() =>
-      checkNode(
-        scope,
-        { ...request, relation: computedUserset },
-        depth,
-        path,
-        frame,
-      ),
+    handlers.push((branch) =>
+      checkNode(scope, { ...request, relation: computedUserset }, depth, path, {
+        waits: frame.waits,
+        branch,
+      }),
     );
   }
 
@@ -960,7 +1044,8 @@ async function checkBase(
   // moves to another object, so each child costs one depth.
   if (config?.tupleToUserset) {
     const ttuEntries = config.tupleToUserset;
-    handlers.push(async () => {
+    handlers.push(async (branch) => {
+      if (branch.abandoned) throw new BranchAbandoned();
       // Batch all tupleset lookups
       const linkedResults = await Promise.all(
         ttuEntries.map(({ tupleset }) =>
@@ -973,11 +1058,11 @@ async function checkBase(
       );
 
       // Collect all linked-tuple check handlers
-      const ttuHandlers: Array<() => Promise<CheckResult>> = [];
+      const ttuHandlers: Handler[] = [];
       for (const [i, { computedUserset }] of ttuEntries.entries()) {
         const linkedTuples = linkedResults[i] ?? [];
         for (const linked of linkedTuples) {
-          ttuHandlers.push(() =>
+          ttuHandlers.push((child) =>
             checkNode(
               scope,
               {
@@ -990,17 +1075,17 @@ async function checkBase(
               },
               depth + 1,
               path,
-              frame,
+              { waits: frame.waits, branch: child },
             ),
           );
         }
       }
 
-      return resolveUnion(ttuHandlers, maxBreadth);
+      return resolveUnion(ttuHandlers, maxBreadth, branch);
     });
   }
 
-  return resolveUnion(handlers, maxBreadth);
+  return resolveUnion(handlers, maxBreadth, frame.branch);
 }
 
 /**
@@ -1028,35 +1113,42 @@ async function checkIntersection(
     );
   }
 
-  const handlers: Array<() => Promise<CheckResult>> = [];
+  const handlers: Handler[] = [];
 
   for (const operand of operands) {
     if (operand.type === "direct") {
-      handlers.push(() =>
-        checkBase(scope, request, config, reads, depth, path, frame),
+      handlers.push((branch) =>
+        checkBase(scope, request, config, reads, depth, path, {
+          waits: frame.waits,
+          branch,
+        }),
       );
     } else if (operand.type === "computedUserset") {
       // Same object, no depth cost — as with the other rewrites.
-      handlers.push(() =>
+      handlers.push((branch) =>
         checkNode(
           scope,
           { ...request, relation: operand.relation },
           depth,
           path,
-          frame,
+          {
+            waits: frame.waits,
+            branch,
+          },
         ),
       );
     } else {
       // tupleToUserset operand
-      handlers.push(async () => {
+      handlers.push(async (branch) => {
+        if (branch.abandoned) throw new BranchAbandoned();
         const linkedTuples = await store.findTuplesByRelation(
           request.objectType,
           request.objectId,
           operand.tupleset,
         );
-        const ttuHandlers: Array<() => Promise<CheckResult>> = [];
+        const ttuHandlers: Handler[] = [];
         for (const linked of linkedTuples) {
-          ttuHandlers.push(() =>
+          ttuHandlers.push((child) =>
             checkNode(
               scope,
               {
@@ -1069,16 +1161,16 @@ async function checkIntersection(
               },
               depth + 1,
               path,
-              frame,
+              { waits: frame.waits, branch: child },
             ),
           );
         }
-        return resolveUnion(ttuHandlers, maxBreadth);
+        return resolveUnion(ttuHandlers, maxBreadth, branch);
       });
     }
   }
 
-  return resolveIntersection(handlers, maxBreadth);
+  return resolveIntersection(handlers, maxBreadth, frame.branch);
 }
 
 /**
@@ -1091,10 +1183,11 @@ async function checkIntersection(
  * when the union settles are never started.
  */
 function resolveUnion(
-  handlers: Array<() => Promise<CheckResult>>,
+  handlers: Handler[],
   maxBreadth: number,
+  parent: Branch,
 ): Promise<CheckResult> {
-  return resolveShortCircuit(handlers, maxBreadth, UNION_REDUCER);
+  return resolveShortCircuit(handlers, maxBreadth, UNION_REDUCER, parent);
 }
 
 /**
@@ -1108,10 +1201,16 @@ function resolveUnion(
  * intersection settles are never started.
  */
 function resolveIntersection(
-  handlers: Array<() => Promise<CheckResult>>,
+  handlers: Handler[],
   maxBreadth: number,
+  parent: Branch,
 ): Promise<CheckResult> {
-  return resolveShortCircuit(handlers, maxBreadth, INTERSECTION_REDUCER);
+  return resolveShortCircuit(
+    handlers,
+    maxBreadth,
+    INTERSECTION_REDUCER,
+    parent,
+  );
 }
 
 /**
@@ -1136,13 +1235,21 @@ function resolveIntersection(
  * scheduling-dependent, as it is in OpenFGA (whose union keeps the
  * last-completed error instead).
  *
+ * Every launched handler gets a branch of its own, and settling
+ * abandons all of them: a branch whose answer is no longer wanted
+ * stops at its next checkpoint instead of walking its subtree and
+ * reading a store the caller has already finished with. Abandoning
+ * on exhaustion is a no-op — nothing is still running — so the one
+ * call covers both exits.
+ *
  * Exported for direct unit tests only; not part of the public
  * package API (not re-exported from index.ts).
  */
 export function resolveShortCircuit(
-  handlers: Array<() => Promise<CheckResult>>,
+  handlers: Handler[],
   maxBreadth: number,
   reducer: Reducer,
+  parent: Branch = new Branch(null),
 ): Promise<CheckResult> {
   return new Promise((resolve, reject) => {
     let next = 0;
@@ -1151,9 +1258,17 @@ export function resolveShortCircuit(
     let firstError: unknown;
     let hasError = false;
     let accumulated = reducer.initial;
+    const launched: Branch[] = [];
+
+    const abandonLosers = () => {
+      for (const branch of launched) {
+        branch.abandon();
+      }
+    };
 
     const settleExhausted = () => {
       settled = true;
+      abandonLosers();
       if (hasError) {
         reject(firstError);
       } else {
@@ -1176,9 +1291,11 @@ export function resolveShortCircuit(
         next++;
         if (!handler) continue;
         active++;
-        let branch: Promise<CheckResult>;
+        const branch = new Branch(parent);
+        launched.push(branch);
+        let outcome: Promise<CheckResult>;
         try {
-          branch = handler();
+          outcome = handler(branch);
         } catch (error) {
           // A synchronously-throwing handler counts as a rejected
           // branch; without this its slot would leak and the
@@ -1190,12 +1307,13 @@ export function resolveShortCircuit(
           }
           continue;
         }
-        branch.then(
+        outcome.then(
           (result) => {
             if (settled) return;
             const decided = reducer.decide(result);
             if (decided) {
               settled = true;
+              abandonLosers();
               resolve(decided);
               return;
             }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import { check } from "./check.ts";
+import { type CheckOutcome, checkMany } from "./check-many.ts";
 import { listObjects } from "./list-objects.ts";
 import type { TupleStore } from "./store-interface.ts";
 import { validateTupleWrite } from "./tuple-validation.ts";
@@ -25,6 +26,26 @@ export interface TsfgaClient {
    *   same validation `addTuple` applies.
    */
   check(request: CheckRequest): Promise<boolean>;
+  /**
+   * Check several requests against one shared resolution scope, so
+   * a node reached by more than one of them is resolved once for
+   * the whole batch rather than once per call. Use it wherever a
+   * request answers several permission questions at a time: the
+   * saving is the shared part of the graph, which is usually most
+   * of it.
+   *
+   * Answers come back in request order, one per request. A check
+   * that fails reports its error in its own outcome instead of
+   * failing the batch, matching OpenFGA's BatchCheck; only invalid
+   * options throw.
+   *
+   * The scope is bounded by the call, so it can be used inside a
+   * transaction: a tuple written earlier in the same transaction is
+   * visible to it, which is why this is a scope and not a cache.
+   * Requests sharing a `context` object share the memo — pass one
+   * object rather than rebuilding an equal one per request.
+   */
+  checkMany(requests: readonly CheckRequest[]): Promise<CheckOutcome[]>;
   addTuple(request: AddTupleRequest): Promise<void>;
   removeTuple(request: RemoveTupleRequest): Promise<boolean>;
   /**
@@ -74,6 +95,10 @@ export function createTsfga(
   return {
     check(request: CheckRequest): Promise<boolean> {
       return check(store, request, options);
+    },
+
+    checkMany(requests: readonly CheckRequest[]): Promise<CheckOutcome[]> {
+      return checkMany(store, requests, options);
     },
 
     async addTuple(request: AddTupleRequest): Promise<void> {
@@ -140,6 +165,7 @@ export function createTsfga(
 
 // Re-exports
 export { check } from "./check.ts";
+export { type CheckOutcome, checkMany } from "./check-many.ts";
 export { evaluateTupleCondition } from "./conditions.ts";
 export { ContextualTupleStore } from "./contextual-store.ts";
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,6 +127,15 @@ export interface CheckOptions {
    * integer >= 1, or Infinity.
    */
   maxBreadth?: number;
+  /**
+   * Maximum number of whole checks of one `checkMany` batch
+   * resolved concurrently (default: 50, matching OpenFGA's
+   * `OPENFGA_MAX_CONCURRENT_CHECKS_PER_BATCH_CHECK`). A separate
+   * knob from `maxBreadth`, which bounds the branches within one
+   * check. Ignored by `check` and `listObjects`. Must be an
+   * integer >= 1, or Infinity.
+   */
+  maxConcurrentChecks?: number;
 }
 
 /** Parameters for adding a tuple */

--- a/packages/core/tests/check-abandon.test.ts
+++ b/packages/core/tests/check-abandon.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { check } from "../src/check.ts";
+import type {
+  CheckTuples,
+  CheckTuplesQuery,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+/** Serves reads of one relation prefix slowly, the rest at once. */
+class SlowStore extends MockTupleStore {
+  constructor(private readonly slowPrefix: string) {
+    super();
+  }
+
+  override async findCheckTuples(
+    query: CheckTuplesQuery,
+  ): Promise<CheckTuples> {
+    const reply = await super.findCheckTuples(query);
+    if (query.relation.startsWith(this.slowPrefix)) {
+      await new Promise((done) => setTimeout(done, 20));
+    }
+    return reply;
+  }
+}
+
+const settle = (ms: number) => new Promise((done) => setTimeout(done, ms));
+
+/**
+ * A union that has found its grant stops launching queued branches,
+ * but the branches already in flight are a separate question: their
+ * subtrees keep resolving, and keep reading, after `check()` has
+ * returned. The reads are the observable — count them *after* the
+ * call resolves, having drained everything already issued.
+ */
+describe("branches abandoned after the answer is decided", () => {
+  let store: SlowStore;
+
+  const request = {
+    objectType: "doc",
+    objectId: "1",
+    relation: "top",
+    subjectType: "user",
+    subjectId: "alice",
+  };
+
+  beforeEach(() => {
+    store = new SlowStore("slow");
+    // `slow0` heads a chain of five nodes, each read taking 20ms.
+    // `fast` grants outright. Both are launched together; `fast`
+    // wins while `slow0`'s read is still in flight.
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "top",
+        impliedBy: ["slow0", "fast"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "slow0",
+        impliedBy: ["slow1"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "slow1",
+        impliedBy: ["slow2"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "slow2",
+        impliedBy: ["slow3"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "slow3",
+        impliedBy: ["slow4"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "slow4",
+        directlyAssignableTypes: ["user"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "fast",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+    store.tuples.push(
+      makeTuple({
+        objectType: "doc",
+        objectId: "1",
+        relation: "fast",
+        subjectType: "user",
+        subjectId: "alice",
+      }),
+    );
+  });
+
+  test("the losing branch stops reading the store", async () => {
+    store.resetCounts();
+    expect(await check(store, request, { maxBreadth: 10 })).toBe(true);
+
+    // The read `slow0` had already handed to the store cannot be
+    // called back, so one slow read is expected. What must not
+    // happen is the other four: the chain walking on past the
+    // answer.
+    const duringCheck = store.counts.findCheckTuples ?? 0;
+    await settle(200);
+    const afterCheck = store.counts.findCheckTuples ?? 0;
+
+    expect(afterCheck).toBe(duringCheck);
+    expect(store.callsWith("findCheckTuples", "doc", "1", "slow1")).toBe(0);
+    expect(store.callsWith("findCheckTuples", "doc", "1", "slow4")).toBe(0);
+  });
+
+  test("abandonment never leaks out as an error", async () => {
+    // The sentinel an abandoned branch rejects with is internal. It
+    // reaches a combinator that has already settled and stops
+    // there; a caller must never see it, whatever the answer.
+    for (const maxBreadth of [1, 2, 10, Number.POSITIVE_INFINITY]) {
+      expect(await check(store, request, { maxBreadth })).toBe(true);
+    }
+    await settle(200);
+  });
+
+  test("a denial still walks every branch", async () => {
+    // Control: abandonment must not truncate a check that has not
+    // been decided. With no grant anywhere, the whole chain is
+    // still read.
+    store.tuples.length = 0;
+    store.resetCounts();
+
+    expect(await check(store, request, { maxBreadth: 10 })).toBe(false);
+    expect(store.callsWith("findCheckTuples", "doc", "1", "slow4")).toBe(1);
+  });
+});

--- a/packages/core/tests/check-breadth.test.ts
+++ b/packages/core/tests/check-breadth.test.ts
@@ -598,8 +598,12 @@ describe("resolveShortCircuit hardening", () => {
     expect(unionGranted.allowed).toBe(true);
     expect(unionGranted.cycleDetected).toBe(false);
 
-    // Intersection: a cycle decides the whole operand set, and
-    // carries its flag out.
+    // Intersection: the first failing operand decides and carries
+    // its flag out, whichever kind of failure it is. So the same
+    // operand set answers differently depending on which failure
+    // is reached first — deliberately, because that is what
+    // upstream does and the flag is visible one level up. See
+    // tests/conformance/intersection-cycle-precedence.test.ts.
     const intersected = await resolveShortCircuit(
       [grant, cycle, grant],
       1,
@@ -607,6 +611,22 @@ describe("resolveShortCircuit hardening", () => {
     );
     expect(intersected.allowed).toBe(false);
     expect(intersected.cycleDetected).toBe(true);
+
+    const cycleFirst = await resolveShortCircuit(
+      [cycle, deny],
+      1,
+      INTERSECTION_REDUCER,
+    );
+    expect(cycleFirst.allowed).toBe(false);
+    expect(cycleFirst.cycleDetected).toBe(true);
+
+    const denyFirst = await resolveShortCircuit(
+      [deny, cycle],
+      1,
+      INTERSECTION_REDUCER,
+    );
+    expect(denyFirst.allowed).toBe(false);
+    expect(denyFirst.cycleDetected).toBe(false);
 
     // An error still outranks a cycle-flagged false in a union.
     await expect(

--- a/packages/core/tests/check-many.test.ts
+++ b/packages/core/tests/check-many.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { checkMany } from "../src/check-many.ts";
+import {
+  InvalidSubjectTypeError,
+  RelationConfigNotFoundError,
+  TsfgaError,
+} from "../src/errors.ts";
+import type {
+  ConditionDefinition,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
+import { MockTupleStore } from "./helpers/mock-store.ts";
+
+function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
+  return {
+    objectType: "",
+    objectId: "",
+    relation: "",
+    subjectType: "",
+    subjectId: "",
+    subjectRelation: null,
+    conditionName: null,
+    conditionContext: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
+  return {
+    objectType: "",
+    relation: "",
+    directlyAssignableTypes: null,
+    impliedBy: null,
+    computedUserset: null,
+    tupleToUserset: null,
+    excludedBy: null,
+    intersection: null,
+    allowsUsersetSubjects: false,
+    ...overrides,
+  };
+}
+
+const alice = { subjectType: "user", subjectId: "alice" };
+
+describe("checkMany", () => {
+  let store: MockTupleStore;
+
+  beforeEach(() => {
+    store = new MockTupleStore();
+  });
+
+  /**
+   * Two permissions on one object, both reached through the same
+   * `shared` node — the shape of a page render asking several
+   * questions about one record.
+   */
+  function seedSharedSubtree() {
+    store.relationConfigs.push(
+      makeConfig({
+        objectType: "doc",
+        relation: "can_view",
+        impliedBy: ["shared"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "can_edit",
+        impliedBy: ["shared"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "shared",
+        impliedBy: ["deep"],
+      }),
+      makeConfig({
+        objectType: "doc",
+        relation: "deep",
+        directlyAssignableTypes: ["user"],
+      }),
+    );
+  }
+
+  describe("one scope spans the batch", () => {
+    test("a shared subtree is resolved once for the batch", async () => {
+      seedSharedSubtree();
+      store.resetCounts();
+
+      const outcomes = await checkMany(store, [
+        { objectType: "doc", objectId: "1", relation: "can_view", ...alice },
+        { objectType: "doc", objectId: "1", relation: "can_edit", ...alice },
+      ]);
+
+      expect(outcomes.map((o) => o.allowed)).toEqual([false, false]);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "shared")).toBe(1);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "deep")).toBe(1);
+      // And the config cache spans the batch too.
+      expect(store.callsWith("findRelationConfig", "doc", "shared")).toBe(1);
+    });
+
+    test("two identical requests cost one resolution", async () => {
+      // Upstream de-duplicates a batch by cache key before
+      // dispatching; here the shared scope does it at the root node.
+      seedSharedSubtree();
+      store.resetCounts();
+
+      const request = {
+        objectType: "doc",
+        objectId: "1",
+        relation: "can_view",
+        ...alice,
+      };
+      const outcomes = await checkMany(store, [request, request]);
+
+      expect(outcomes.map((o) => o.allowed)).toEqual([false, false]);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "can_view")).toBe(
+        1,
+      );
+    });
+
+    test("separate check calls still pay per call", async () => {
+      // Control: the counts above are the scope's doing, not the
+      // fixture being trivially small.
+      seedSharedSubtree();
+      store.resetCounts();
+
+      await checkMany(store, [
+        { objectType: "doc", objectId: "1", relation: "can_view", ...alice },
+      ]);
+      await checkMany(store, [
+        { objectType: "doc", objectId: "1", relation: "can_edit", ...alice },
+      ]);
+
+      expect(store.callsWith("findCheckTuples", "doc", "1", "shared")).toBe(2);
+    });
+  });
+
+  describe("answers", () => {
+    test("come back in request order", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "2",
+          relation: "viewer",
+          ...alice,
+        }),
+      );
+
+      const outcomes = await checkMany(store, [
+        { objectType: "doc", objectId: "1", relation: "viewer", ...alice },
+        { objectType: "doc", objectId: "2", relation: "viewer", ...alice },
+        { objectType: "doc", objectId: "3", relation: "viewer", ...alice },
+      ]);
+
+      expect(outcomes.map((o) => o.allowed)).toEqual([false, true, false]);
+    });
+
+    test("an empty batch answers nothing", async () => {
+      expect(await checkMany(store, [])).toEqual([]);
+    });
+
+    test("order holds at every concurrency bound", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      const ids = ["1", "2", "3", "4", "5"];
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "3",
+          relation: "viewer",
+          ...alice,
+        }),
+      );
+      const requests = ids.map((objectId) => ({
+        objectType: "doc",
+        objectId,
+        relation: "viewer",
+        ...alice,
+      }));
+
+      for (const maxConcurrentChecks of [1, 2, 50, Number.POSITIVE_INFINITY]) {
+        const outcomes = await checkMany(store, requests, {
+          maxConcurrentChecks,
+        });
+        expect(outcomes.map((o) => o.allowed)).toEqual([
+          false,
+          false,
+          true,
+          false,
+          false,
+        ]);
+      }
+    });
+  });
+
+  describe("errors are per check, not per batch", () => {
+    test("a failing check does not stop the others", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+        }),
+      );
+
+      const outcomes = await checkMany(store, [
+        {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          // Validated exactly as `addTuple` would validate it, and
+          // this relation admits `user` subjects only.
+          contextualTuples: [
+            {
+              objectType: "doc",
+              objectId: "9",
+              relation: "viewer",
+              subjectType: "team",
+              subjectId: "eng",
+              subjectRelation: "member",
+            },
+          ],
+        },
+        { objectType: "doc", objectId: "1", relation: "viewer", ...alice },
+        {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          // No relation config for `doc.missing` to validate against.
+          contextualTuples: [
+            {
+              objectType: "doc",
+              objectId: "9",
+              relation: "missing",
+              ...alice,
+            },
+          ],
+        },
+        { objectType: "doc", objectId: "1", relation: "viewer", ...alice },
+      ]);
+
+      expect(outcomes[0]?.allowed).toBe(false);
+      expect(outcomes[0]?.error).toBeInstanceOf(InvalidSubjectTypeError);
+      expect(outcomes[1]).toEqual({ allowed: true });
+      expect(outcomes[2]?.error).toBeInstanceOf(RelationConfigNotFoundError);
+      expect(outcomes[3]).toEqual({ allowed: true });
+    });
+
+    test("an invalid option throws instead", async () => {
+      // Options are the caller's mistake, not a check's outcome.
+      await expect(
+        checkMany(store, [], { maxConcurrentChecks: 0 }),
+      ).rejects.toBeInstanceOf(TsfgaError);
+      await expect(
+        checkMany(store, [], { maxConcurrentChecks: 1.5 }),
+      ).rejects.toBeInstanceOf(TsfgaError);
+      await expect(
+        checkMany(store, [], { maxBreadth: 0 }),
+      ).rejects.toBeInstanceOf(TsfgaError);
+    });
+  });
+
+  describe("context is not shared across contexts", () => {
+    /** `viewer` granted only while the condition holds. */
+    function seedConditioned() {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "viewer",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          conditionName: "is_open",
+        }),
+      );
+      const condition: ConditionDefinition = {
+        name: "is_open",
+        expression: "open == true",
+        parameters: { open: "bool" },
+      };
+      store.conditionDefinitions.push(condition);
+    }
+
+    test("two contexts get two answers", async () => {
+      // The memo does not key on the context, so requests carrying
+      // different contexts must not share one. If they did, the
+      // second answer here would be a copy of the first.
+      seedConditioned();
+
+      const outcomes = await checkMany(store, [
+        {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          context: { open: true },
+        },
+        {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          context: { open: false },
+        },
+      ]);
+
+      expect(outcomes.map((o) => o.allowed)).toEqual([true, false]);
+    });
+
+    test("one context object is shared", async () => {
+      seedConditioned();
+      store.resetCounts();
+      const context = { open: true };
+
+      const outcomes = await checkMany(store, [
+        {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          context,
+        },
+        {
+          objectType: "doc",
+          objectId: "1",
+          relation: "viewer",
+          ...alice,
+          context,
+        },
+      ]);
+
+      expect(outcomes.map((o) => o.allowed)).toEqual([true, true]);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "viewer")).toBe(1);
+    });
+  });
+});

--- a/packages/core/tests/check-memo.test.ts
+++ b/packages/core/tests/check-memo.test.ts
@@ -355,13 +355,21 @@ describe("request-scoped node memoization", () => {
           relation: "top",
           impliedBy: ["left", "right"],
         }),
-        makeConfig({ objectType: "doc", relation: "left", impliedBy: ["deep"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "left",
+          impliedBy: ["deep"],
+        }),
         makeConfig({
           objectType: "doc",
           relation: "right",
           impliedBy: ["deep"],
         }),
-        makeConfig({ objectType: "doc", relation: "deep", impliedBy: ["leaf"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "deep",
+          impliedBy: ["leaf"],
+        }),
         makeConfig({
           objectType: "doc",
           relation: "leaf",

--- a/packages/core/tests/check-memo.test.ts
+++ b/packages/core/tests/check-memo.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { check } from "../src/check.ts";
 import { DepthExceededError } from "../src/errors.ts";
-import type { RelationConfig, Tuple } from "../src/types.ts";
+import type {
+  CheckTuples,
+  CheckTuplesQuery,
+  RelationConfig,
+  Tuple,
+} from "../src/types.ts";
 import { MockTupleStore } from "./helpers/mock-store.ts";
 
 function makeTuple(overrides: Partial<Tuple> = {}): Tuple {
@@ -34,6 +39,27 @@ function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
 }
 
 /**
+ * Fails the first read of one relation and serves every later one.
+ * Enough to make an in-flight entry reject while the node it stands
+ * for is perfectly resolvable on a second attempt.
+ */
+class FailFirstStore extends MockTupleStore {
+  private failed = false;
+
+  constructor(private readonly relation: string) {
+    super();
+  }
+
+  override findCheckTuples(query: CheckTuplesQuery): Promise<CheckTuples> {
+    if (query.relation === this.relation && !this.failed) {
+      this.failed = true;
+      return Promise.reject(new Error("transient store failure"));
+    }
+    return super.findCheckTuples(query);
+  }
+}
+
+/**
  * These tests count `findCheckTuples` as the "this node was
  * resolved" signal. A node makes exactly one of those calls, for
  * whichever of the three reads its relation config admits, so the
@@ -41,11 +67,10 @@ function makeConfig(overrides: Partial<RelationConfig> = {}): RelationConfig {
  * arguments needed to disambiguate.
  *
  * Every test here runs at `maxBreadth: 1` unless it says otherwise.
- * The memo publishes settled results only — never in-flight
- * promises, which would deadlock when two sibling branches each
- * end up awaiting the other's entry — so a hit requires one branch
- * to have finished before the other starts. Bounded breadth makes
- * that ordering deterministic instead of a race.
+ * The settled memo only answers a route that arrives after another
+ * route finished, so a hit requires that ordering; bounded breadth
+ * makes it deterministic instead of a race. Routes that *overlap*
+ * are the in-flight registry's job — see the last block.
  */
 const SEQUENTIAL = { maxBreadth: 1 };
 
@@ -178,10 +203,11 @@ describe("request-scoped node memoization", () => {
     });
 
     test("a cross-branch cycle terminates instead of deadlocking", async () => {
-      // The shape that rules out coalescing in-flight promises:
+      // The shape that makes naive in-flight coalescing deadlock:
       // at breadth >= 2 both branches are launched before either
-      // settles, and each would end up awaiting the other's entry.
-      // With settled results only there is nothing to await.
+      // settles, and each reaches the other's node, which is not on
+      // its own path. The wait graph refuses the second of the two
+      // waits, and that branch resolves the node itself.
       store.relationConfigs.push(
         makeConfig({
           objectType: "doc",
@@ -311,6 +337,176 @@ describe("request-scoped node memoization", () => {
       expect(
         await check(store, viewerRequest, { maxBreadth: 1, maxDepth: 5 }),
       ).toBe(false);
+    });
+  });
+
+  describe("overlapping routes coalesce on one resolution", () => {
+    const CONCURRENT = { maxBreadth: 10 };
+
+    test("sibling branches share one resolution of a shared node", async () => {
+      // The diamond again, but at a breadth that launches both
+      // branches before either settles. The settled memo cannot
+      // help here — when `right` asks for `shared`, `left` has not
+      // finished with it — so a second read would mean the DAG is
+      // being walked as a tree.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["left", "right"],
+        }),
+        makeConfig({ objectType: "doc", relation: "left", impliedBy: ["deep"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "right",
+          impliedBy: ["deep"],
+        }),
+        makeConfig({ objectType: "doc", relation: "deep", impliedBy: ["leaf"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "leaf",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, CONCURRENT)).toBe(false);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "deep")).toBe(1);
+      // And the whole subtree behind it, not just the shared node.
+      expect(store.callsWith("findCheckTuples", "doc", "1", "leaf")).toBe(1);
+    });
+
+    test("a grant found by one branch answers the other", async () => {
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["left", "right"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "left",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "right",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "shared",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "shared",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+      store.resetCounts();
+
+      expect(await check(store, viewerRequest, CONCURRENT)).toBe(true);
+      expect(store.callsWith("findCheckTuples", "doc", "1", "shared")).toBe(1);
+    });
+
+    test("a three-branch wait cycle terminates", async () => {
+      // Pairwise detection is not enough: a waits on b, b on c, and
+      // only c closes the loop back to a. The refusal has to walk
+      // the wait graph transitively to see it.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["a", "b", "c"],
+        }),
+        makeConfig({ objectType: "doc", relation: "a", impliedBy: ["b"] }),
+        makeConfig({ objectType: "doc", relation: "b", impliedBy: ["c"] }),
+        makeConfig({ objectType: "doc", relation: "c", impliedBy: ["a"] }),
+      );
+
+      expect(await check(store, viewerRequest, { maxBreadth: 3 })).toBe(false);
+    });
+
+    test("a cycle behind a grant does not hide it", async () => {
+      // The refusal must not swallow an answer: `c` loops back
+      // through the wait graph, and `granted` still wins.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["a", "b", "c", "granted"],
+        }),
+        makeConfig({ objectType: "doc", relation: "a", impliedBy: ["b"] }),
+        makeConfig({ objectType: "doc", relation: "b", impliedBy: ["c"] }),
+        makeConfig({ objectType: "doc", relation: "c", impliedBy: ["a"] }),
+        makeConfig({
+          objectType: "doc",
+          relation: "granted",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "granted",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      expect(await check(store, viewerRequest, { maxBreadth: 4 })).toBe(true);
+    });
+
+    test("a coalesced waiter does not adopt the entry's error", async () => {
+      // Errors are not path-independent — a sibling truncated by a
+      // cycle can hide an error on one route and not another — so a
+      // waiter re-resolves rather than inheriting a rejection. Here
+      // the shared node's first read fails and its second succeeds:
+      // `left` errors, `right` coalesces onto that same failing
+      // resolution, and must still find the grant on its own.
+      store.relationConfigs.push(
+        makeConfig({
+          objectType: "doc",
+          relation: "top",
+          impliedBy: ["left", "right"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "left",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "right",
+          impliedBy: ["shared"],
+        }),
+        makeConfig({
+          objectType: "doc",
+          relation: "shared",
+          directlyAssignableTypes: ["user"],
+        }),
+      );
+      store.tuples.push(
+        makeTuple({
+          objectType: "doc",
+          objectId: "1",
+          relation: "shared",
+          subjectType: "user",
+          subjectId: "alice",
+        }),
+      );
+
+      const flaky = new FailFirstStore("shared");
+      flaky.relationConfigs = store.relationConfigs;
+      flaky.tuples = store.tuples;
+
+      expect(await check(flaky, viewerRequest, CONCURRENT)).toBe(true);
     });
   });
 

--- a/tests/conformance/intersection-cycle-precedence.test.ts
+++ b/tests/conformance/intersection-cycle-precedence.test.ts
@@ -1,0 +1,339 @@
+import { afterAll, beforeAll, describe, test } from "bun:test";
+import { createTsfga, type TsfgaClient } from "@tsfga/core";
+import type { DB } from "@tsfga/kysely";
+import { KyselyTupleStore } from "@tsfga/kysely";
+import type { Kysely } from "kysely";
+import { expectConformance } from "./helpers/conformance.ts";
+import {
+  beginTransaction,
+  destroyDb,
+  getDb,
+  rollbackTransaction,
+} from "./helpers/db.ts";
+import {
+  fgaCreateStore,
+  fgaWriteModel,
+  fgaWriteTuples,
+} from "./helpers/openfga.ts";
+
+// Which operand gets to decide an intersection.
+//
+// An intersection denies as soon as one operand fails to hold.
+// Two kinds of operand fail to hold and they are not equivalent: a
+// definitive `false`, and a branch truncated by a cycle. The
+// denial is the same; what differs is whether it carries the
+// indeterminacy flag, and one level up that flag is the whole
+// answer — on the subtract side of a `but not`, a cycle denies and
+// a plain `false` does not.
+//
+// OpenFGA takes the *first* of the two to arrive
+// (`internal/graph/check.go`, `intersection`: the outcome loop
+// short-circuits on `CycleDetected || !Allowed` and propagates
+// that outcome's flag). So its answer tracks which operand is
+// cheaper to resolve. tsfga's combinator races the operands the
+// same way and therefore lands in the same place — but only as
+// long as it keeps racing. Preferring one kind of failure over the
+// other, however tempting it is to call the definitive one
+// "better", diverges the moment the other operand is the cheap
+// one, and diverges in the fail-open direction.
+//
+// This fixture pins both halves of that, on a model OpenFGA
+// accepts. It was written after a change that preferred the
+// definitive `false` shipped on a branch, made this exact check
+// answer `true` where OpenFGA answers `false`, and was caught only
+// because it was probed against the running container.
+//
+// Two constraints are inherited from the `cycles` fixture and are
+// load-bearing here too: the cycle has to come from tuples,
+// because OpenFGA's typesystem rejects a model-level one; and it
+// has to alternate two relations, because a single
+// self-referencing relation is served by the recursive resolver,
+// which returns a definitive `false` and never sets the flag.
+//
+// The race is decided by a deliberate cost asymmetry: `chain9` is
+// nine sequential tuple-to-userset dispatches, `cyclic` is three
+// reads. That gap is what makes the cycle win reproducibly on both
+// systems rather than sometimes.
+//
+// Ref: https://github.com/openfga/openfga/blob/560d5d3dd46b5adda9ecfb29efeb4f4f70c96327/internal/graph/check.go#L277
+
+const uuidMap = new Map<string, string>([
+  ["anne", "00000000-0000-4000-c800-000000000001"],
+  ["loopa", "00000000-0000-4000-c800-000000000002"],
+  ["loopb", "00000000-0000-4000-c800-000000000003"],
+  ...Array.from({ length: 11 }, (_, i): [string, string] => [
+    `${i + 1}`,
+    `00000000-0000-4000-c800-0000000001${String(i + 1).padStart(2, "0")}`,
+  ]),
+]);
+
+function uuid(name: string): string {
+  const id = uuidMap.get(name);
+  if (!id) throw new Error(`No UUID for ${name}`);
+  return id;
+}
+
+const CHAIN_LENGTH = 9;
+
+describe("Intersection Cycle Precedence Conformance", () => {
+  let db: Kysely<DB>;
+  let storeId: string;
+  let authorizationModelId: string;
+  let tsfgaClient: TsfgaClient;
+
+  async function expectCheck(
+    relation: string,
+    expected: boolean,
+  ): Promise<void> {
+    await expectConformance(
+      storeId,
+      authorizationModelId,
+      tsfgaClient,
+      {
+        objectType: "document",
+        objectId: uuid("1"),
+        relation,
+        subjectType: "user",
+        subjectId: uuid("anne"),
+      },
+      expected,
+    );
+  }
+
+  beforeAll(async () => {
+    db = getDb();
+    await beginTransaction(db);
+
+    const store = new KyselyTupleStore(db);
+    tsfgaClient = createTsfga(store);
+
+    const base = {
+      impliedBy: null,
+      computedUserset: null,
+      tupleToUserset: null,
+      excludedBy: null,
+      intersection: null,
+    } as const;
+
+    await tsfgaClient.writeConditionDefinition({
+      name: "valid_ip",
+      expression: 'user_ip == "192.168.0.1"',
+      parameters: { user_ip: "string" },
+    });
+
+    // === group: the two-relation loop ===
+    for (const relation of ["member", "owner"]) {
+      await tsfgaClient.writeRelationConfig({
+        ...base,
+        objectType: "group",
+        relation,
+        directlyAssignableTypes: ["user", "group"],
+        allowsUsersetSubjects: true,
+      });
+    }
+
+    // === document ===
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "parent",
+      directlyAssignableTypes: ["document"],
+      allowsUsersetSubjects: false,
+    });
+    for (const relation of ["base", "chain0"]) {
+      await tsfgaClient.writeRelationConfig({
+        ...base,
+        objectType: "document",
+        relation,
+        directlyAssignableTypes: ["user"],
+        allowsUsersetSubjects: false,
+      });
+    }
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "conditioned",
+      directlyAssignableTypes: ["user"],
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "cyclic",
+      directlyAssignableTypes: ["group"],
+      allowsUsersetSubjects: true,
+    });
+    // The slow operand: nine sequential TTU hops that find nothing.
+    for (let k = 1; k <= CHAIN_LENGTH; k++) {
+      await tsfgaClient.writeRelationConfig({
+        ...base,
+        objectType: "document",
+        relation: `chain${k}`,
+        directlyAssignableTypes: null,
+        tupleToUserset: [
+          { tupleset: "parent", computedUserset: `chain${k - 1}` },
+        ],
+        allowsUsersetSubjects: false,
+      });
+    }
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "slow_and_cycle",
+      directlyAssignableTypes: null,
+      intersection: [
+        { type: "computedUserset", relation: `chain${CHAIN_LENGTH}` },
+        { type: "computedUserset", relation: "cyclic" },
+      ],
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "blocked",
+      directlyAssignableTypes: null,
+      impliedBy: ["slow_and_cycle"],
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "guarded",
+      directlyAssignableTypes: null,
+      impliedBy: ["base"],
+      excludedBy: "blocked",
+      allowsUsersetSubjects: false,
+    });
+    await tsfgaClient.writeRelationConfig({
+      ...base,
+      objectType: "document",
+      relation: "errored_and_cycle",
+      directlyAssignableTypes: null,
+      intersection: [
+        { type: "computedUserset", relation: "conditioned" },
+        { type: "computedUserset", relation: "cyclic" },
+      ],
+      allowsUsersetSubjects: false,
+    });
+
+    // === Tuples ===
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "cyclic",
+      subjectType: "group",
+      subjectId: uuid("loopa"),
+      subjectRelation: "member",
+    });
+    await tsfgaClient.addTuple({
+      objectType: "group",
+      objectId: uuid("loopa"),
+      relation: "member",
+      subjectType: "group",
+      subjectId: uuid("loopb"),
+      subjectRelation: "owner",
+    });
+    await tsfgaClient.addTuple({
+      objectType: "group",
+      objectId: uuid("loopb"),
+      relation: "owner",
+      subjectType: "group",
+      subjectId: uuid("loopa"),
+      subjectRelation: "member",
+    });
+
+    // The parent chain the slow operand walks. No `chain0` tuple
+    // exists anywhere on it, so `chain9` is definitively false.
+    for (let k = 1; k <= 10; k++) {
+      await tsfgaClient.addTuple({
+        objectType: "document",
+        objectId: uuid(`${k}`),
+        relation: "parent",
+        subjectType: "document",
+        subjectId: uuid(`${k + 1}`),
+      });
+    }
+
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "base",
+      subjectType: "user",
+      subjectId: uuid("anne"),
+    });
+    // No stored context, and the checks below send none, so
+    // evaluating this condition fails.
+    await tsfgaClient.addTuple({
+      objectType: "document",
+      objectId: uuid("1"),
+      relation: "conditioned",
+      subjectType: "user",
+      subjectId: uuid("anne"),
+      conditionName: "valid_ip",
+    });
+
+    storeId = await fgaCreateStore("intersection-cycle-precedence");
+    authorizationModelId = await fgaWriteModel(
+      storeId,
+      "./intersection-cycle-precedence/model.dsl",
+    );
+    await fgaWriteTuples(
+      storeId,
+      "./intersection-cycle-precedence/tuples.yaml",
+      authorizationModelId,
+      uuidMap,
+    );
+  });
+
+  afterAll(async () => {
+    await rollbackTransaction(db);
+    await destroyDb();
+  });
+
+  test("1: the slow operand is definitively false on its own", async () => {
+    // Control. Nothing on the parent chain holds `chain0`, and the
+    // walk terminates rather than erroring, so this is an ordinary
+    // denial with no indeterminacy anywhere in it.
+    await expectCheck(`chain${CHAIN_LENGTH}`, false);
+  });
+
+  test("2: the cycle operand denies on its own", async () => {
+    // Control. Same denial, different kind: the subtree looped
+    // back on itself and was truncated.
+    await expectCheck("cyclic", false);
+  });
+
+  test("3: the intersection of the two denies", async () => {
+    // Control. Whichever operand decides, an intersection missing
+    // one operand denies. The flag is invisible from here — which
+    // is exactly why the next case is needed.
+    await expectCheck("slow_and_cycle", false);
+  });
+
+  test("4: the cheaper operand's cycle survives into the subtraction", async () => {
+    // The case that matters, and the only place the two denials
+    // are distinguishable. `base` grants, so `guarded` hinges
+    // entirely on what `blocked` carries: a cycle-flagged denial
+    // means the exclusion could not be ruled out and access is
+    // denied; a plain `false` means nothing is excluded and access
+    // is granted.
+    //
+    // The cycle operand is three reads and the definitive one is
+    // nine dispatches, so the cycle arrives first and OpenFGA
+    // propagates its flag. Answering `true` here means the
+    // intersection preferred the definitive `false` over the
+    // cheaper cycle — a divergence, and a fail-open one.
+    await expectCheck("guarded", false);
+  });
+
+  test("5: an errored operand does not outrank a cycled one", async () => {
+    // `conditioned` raises a condition-evaluation error (the tuple
+    // stores no context and the check sends none); `cyclic` is
+    // truncated. Upstream records the error, keeps reading
+    // outcomes, and short-circuits `false` on the cycle — so an
+    // error alongside a cycle is a denial, not a failure. Letting
+    // the error win instead turns a deny into a thrown error and
+    // fails this check rather than answering it.
+    await expectCheck("errored_and_cycle", false);
+  });
+});

--- a/tests/conformance/intersection-cycle-precedence/model.dsl
+++ b/tests/conformance/intersection-cycle-precedence/model.dsl
@@ -1,0 +1,34 @@
+model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define member: [user, group#owner]
+    define owner: [user, group#member]
+
+type document
+  relations
+    define parent: [document]
+    define base: [user]
+    define cyclic: [group#member]
+    define conditioned: [user with valid_ip]
+    define chain0: [user]
+    define chain1: chain0 from parent
+    define chain2: chain1 from parent
+    define chain3: chain2 from parent
+    define chain4: chain3 from parent
+    define chain5: chain4 from parent
+    define chain6: chain5 from parent
+    define chain7: chain6 from parent
+    define chain8: chain7 from parent
+    define chain9: chain8 from parent
+    define slow_and_cycle: chain9 and cyclic
+    define blocked: slow_and_cycle
+    define guarded: base but not blocked
+    define errored_and_cycle: conditioned and cyclic
+
+condition valid_ip(user_ip: string) {
+  user_ip == "192.168.0.1"
+}

--- a/tests/conformance/intersection-cycle-precedence/tuples.yaml
+++ b/tests/conformance/intersection-cycle-precedence/tuples.yaml
@@ -1,0 +1,74 @@
+# An intersection whose operands are one definitive `false` and
+# one cycle-truncated branch. Which of the two OpenFGA reports is
+# decided by which finishes first, and the difference is visible
+# one level up: `guarded` subtracts `blocked`, and on the subtract
+# side of a `but not` a cycle denies while a plain `false` does
+# not.
+#
+# The cycle is built from tuples because OpenFGA's typesystem
+# rejects a model-level one, and it alternates member/owner
+# because a single self-referencing relation is served by the
+# recursive resolver and never sets the flag. Both facts are the
+# same ones the `cycles` fixture rests on.
+#
+# document:1#cyclic -> group:loopa#member -> group:loopb#owner
+#                   -> group:loopa#member  (loop)
+- user: group:loopa#member
+  relation: cyclic
+  object: document:1
+- user: group:loopb#owner
+  relation: member
+  object: group:loopa
+- user: group:loopa#member
+  relation: owner
+  object: group:loopb
+
+# The other operand, `chain9`, is definitively false: nobody holds
+# `chain0` anywhere on the parent chain. It is also *slow* — nine
+# sequential tuple-to-userset dispatches against the cycle's three
+# reads — which is what makes the cycle win the race, on both
+# systems, reproducibly.
+- user: document:2
+  relation: parent
+  object: document:1
+- user: document:3
+  relation: parent
+  object: document:2
+- user: document:4
+  relation: parent
+  object: document:3
+- user: document:5
+  relation: parent
+  object: document:4
+- user: document:6
+  relation: parent
+  object: document:5
+- user: document:7
+  relation: parent
+  object: document:6
+- user: document:8
+  relation: parent
+  object: document:7
+- user: document:9
+  relation: parent
+  object: document:8
+- user: document:10
+  relation: parent
+  object: document:9
+- user: document:11
+  relation: parent
+  object: document:10
+
+# anne holds the base grant that `guarded` subtracts from.
+- user: user:anne
+  relation: base
+  object: document:1
+
+# ...and a conditioned grant with no stored context, so evaluating
+# it fails. That is the error operand of `errored_and_cycle`; the
+# `condition-error-siblings` fixture uses the same device.
+- user: user:anne
+  relation: conditioned
+  object: document:1
+  condition:
+    name: valid_ip


### PR DESCRIPTION
## Summary

Answers a perf report from a consumer profiling `@tsfga/core` 0.4.0, whose
server-rendered page spent **87% of its wall clock inside `check()`** — 783
tuple statements for one HTTP request.

- **Concurrent routes into a node now resolve it once** (`549c7e5`). The memo
  published only *settled* results, so above `maxBreadth: 1` the routes
  overlapped and each re-resolved the shared subtree: the resolution DAG walked
  as a tree, with breadth as the multiplier. The consumer measured one immutable
  parent edge read 215 times in a single request. On the bench's DAG shape this
  takes a check from ~289 store calls to ~76.

  The obvious version of this deadlocks — two sibling branches resolving
  mutually recursive relations each await the other's entry, which is why the
  previous round rejected it. So in-flight entries carry a **wait graph**, and a
  wait is taken only when it keeps that graph acyclic.

- **Branches abandoned after a node settles stop querying the store**
  (`be6dfea`). A union that found its grant already refused to *launch* queued
  branches; the ones already in flight kept walking their subtree and reading a
  store the caller believed it was done with. Cooperative, so no change to the
  `TupleStore` contract — the cost is that one read per abandoned branch, the one
  already handed to the store, still lands. Documented, because it invalidates
  naive store instrumentation.

- **`checkMany(requests)` shares one resolution scope across a batch**
  (`1e72be5`). Per-call scopes meant two checks about the same object in one
  request shared nothing; the consumer's page made four such checks and paid for
  four full walks (862 statements, against 21–31 for the same work in one scope).
  Follows BatchCheck's shape: per-item errors that never fail the batch, answers
  in request order, `maxConcurrentChecks` defaulting to 50. Identical requests in
  a batch coalesce and cost one resolution — what upstream gets by de-duplicating
  on a cache key.

  A scope is the right unit and a cache is not: tuple reads must stay inside the
  caller's transaction, so a scope bounded by the batch can be used there while a
  tuple cache could not.

- **`maxBreadth` keeps its default of 10.** With coalescing it is no longer a
  duplication multiplier. What survives of that finding is a store-layer
  question — a single pooled Postgres connection serialises, so concurrency
  buys queueing — and the README now says so.

- **`b4f0d87` pins intersection operand precedence** with a new conformance
  fixture and corrects a README claim that was wrong before this branch: an
  intersection is decided by the first operand that fails to hold, a definitive
  `false` and a cycle-truncated branch are both failures carrying different
  indeterminacy, and an enclosing `but not` reads the difference — so
  `maxBreadth` *can* change the answer there. Matching OpenFGA requires racing
  as it races; see below.

No behaviour change beyond the above. `@tsfga/kysely` is untouched.

## How this was verified

- **367 conformance tests across 28 files** against a live OpenFGA v1.18.2 —
  the arbiter for every claim here.
- **A new conformance fixture**, `intersection-cycle-precedence`, added after an
  earlier revision of this branch made an intersection prefer the definitive
  `false` over a cheaper cycle. That looked more correct and was deterministic,
  and it **granted where OpenFGA denies**, on a model OpenFGA accepts, in the
  fail-open direction. The model that motivated it turned out to be one OpenFGA
  rejects outright (`potential loop`), so the determinism was only ever visible
  where upstream cannot go. Reverted; the fixture is what stops it coming back.
  Both of its cases were confirmed to fail before the revert and pass after,
  with three controls isolating the operands.
- **Differential fuzzing.** A breadth-equivalence harness (every breadth against
  breadth 1) and a batch-equivalence harness (`checkMany` against solo `check`)
  over random cyclic graphs, each split into a strict phase and a liveness-only
  phase: 16,900 and 47,760 cases, 0 divergences in the strict phase, no hangs and
  no leaked internal error classes in either. Both were falsification-probed —
  disable the fix and they fail on the first seed.
- **An independent reference evaluator** (no memo, no coalescing, no
  abandonment, sequential) diffed against the real `check()`: 49,455 cases, 0
  divergences.
- Every commit type-checks and passes the core suite **on its own**, verified per
  commit; history is linear with the version bump last.

## Test plan

- [ ] `bun run turbo:test` — core, kysely, conformance
- [ ] `bun run tsc`, `bun run biome:check`
- [ ] `bun run turbo:test:node` / `turbo:test:deno`
- [ ] Conformance runs against OpenFGA v1.18.2, per `compose.yaml`
