### PR TITLE
Let @tsfga/kysely install beside core 0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
 
       - run: bun run biome:check
 
+      # Cheap, needs no build, and gates the one thing a green
+      # test suite cannot see: whether the adapter's declared
+      # peer range still admits the core it was tested against.
+      - run: bun run check:peer-range
+
   commitlint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -288,13 +293,17 @@ jobs:
 
       # Mirrors release.yml: resolve workspace:* before the
       # checks, so they inspect the manifest that ships.
+      #
+      # devDependencies only. peerDependencies is hand-written
+      # and published verbatim -- see scripts/check-peer-range.sh
+      # for why deriving it from the core version silently
+      # orphaned the adapter on every core minor.
       - name: Resolve workspace protocol
         run: |
           core_ver=$(jq -r .version packages/core/package.json)
           dir=packages/kysely
-          jq --arg v "^$core_ver" \
-            '.peerDependencies["@tsfga/core"] = $v
-             | .devDependencies["@tsfga/core"] = $v' \
+          jq --arg v "$core_ver" \
+            '.devDependencies["@tsfga/core"] = $v' \
             "${dir}/package.json" > "${dir}/package.tmp"
           mv "${dir}/package.tmp" "${dir}/package.json"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,12 +169,26 @@ jobs:
       - name: Run tests (Deno)
         run: bun run turbo:test:deno
 
+      # The last gate before anything reaches npm. CI already
+      # runs this on every PR; repeating it here means a
+      # dispatch from a branch that never opened a PR cannot
+      # publish an adapter whose peer range excludes the
+      # current core.
+      - name: Check peer range
+        run: bun run check:peer-range
+
       # Runs before the packaging checks, and regardless of
       # whether this dispatch publishes, so publint / attw /
       # npm pack inspect the manifest that actually ships. When
-      # this ran afterwards, peerDependencies still read
+      # this ran afterwards, devDependencies still read
       # "workspace:*" at validation time and the substituted
       # string was never linted at all.
+      #
+      # devDependencies only. peerDependencies is hand-written
+      # in package.json and ships verbatim: deriving it from the
+      # core version wrote "^0.4.0", which below 1.0.0 excludes
+      # every later minor, so publishing core 0.5.0 left the
+      # published adapter uninstallable beside it.
       - name: Resolve workspace protocol
         if: inputs.package == '@tsfga/kysely'
         run: |
@@ -182,9 +196,8 @@ jobs:
           core_ver=$(
             jq -r .version packages/core/package.json
           )
-          jq --arg v "^$core_ver" \
-            '.peerDependencies["@tsfga/core"] = $v
-             | .devDependencies["@tsfga/core"] = $v' \
+          jq --arg v "$core_ver" \
+            '.devDependencies["@tsfga/core"] = $v' \
             "${dir}/package.json" > "${dir}/package.tmp"
           mv "${dir}/package.tmp" "${dir}/package.json"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1020,6 +1020,47 @@ See `RELEASING.md` for the full step-by-step process.
 **Version bumps** happen in PRs before release:
 - `scripts/bump.sh <package-dir> [patch|minor|major]`
 
+### Cross-package peer ranges
+
+**`@tsfga/kysely`'s peer range on `@tsfga/core` is hand-written
+in `packages/kysely/package.json` and ships verbatim. Never
+derive it from the core version.**
+
+It must be spelled `>=A.B.C <D.E.F`. Caret and tilde are
+rejected by `scripts/check-peer-range.sh`, because their
+meaning changes at 1.0.0: below it, `^0.4.0` admits only the
+0.4.x line. That is how `@tsfga/kysely@0.4.0` shipped a peer
+range excluding `@tsfga/core@0.5.0` — the release workflow
+substituted `^$core_ver` for `workspace:*` at publish time, so
+no human ever read the range, and no step failed. Only the
+`devDependency` is substituted now; it stays `workspace:*` in
+the repo so the adapter builds against the core beside it.
+
+**Bumping `@tsfga/core`'s minor is not done until the adapter's
+range has been reconsidered in the same PR.** `bump.sh` warns
+and CI fails while the two disagree. Widening is not automatic —
+decide which it is:
+
+- The `TupleStore` interface, its semantics, and the guarantees
+  the adapter relies on are all unchanged (core 0.5.0 → added
+  `checkMany`, touched no store method): raise the ceiling to
+  the next minor, bump `@tsfga/kysely`'s **patch**, and say in
+  its `CHANGELOG.md` why the adapter needs no change.
+- The interface or its semantics changed: update the adapter,
+  raise the **floor** to the new core, and bump
+  `@tsfga/kysely`'s **minor** with the breaking change written
+  out.
+
+Either way the peer range, `packages/kysely/README.md`'s
+installation section, and `CHANGELOG.md` move together — the
+range alone is what consumers hit, but only the README and
+changelog tell them why.
+
+**A core release and the adapter release that follows it are
+two dispatches.** Publish core first, then `@tsfga/kysely`;
+otherwise the adapter's peer range points at a core version npm
+cannot resolve.
+
 **Changelogs** are hand-written. A version-bump PR updates
 the affected package's `CHANGELOG.md` in the same commit as
 the bump. Bot PRs, tooling changes, and docs-only changes do

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/kysely": {
       "name": "@tsfga/kysely",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@tsfga/core": "workspace:*",
         "@types/bun": "1.3.14",
@@ -42,7 +42,7 @@
         "typescript": "6.0.3",
       },
       "peerDependencies": {
-        "@tsfga/core": "workspace:*",
+        "@tsfga/core": ">=0.4.0 <0.6.0",
         "kysely": ">=0.27.0 <0.30.0",
         "pg": ">=8.0.0",
       },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "workspaces": ["packages/*", "tests/*"],
   "scripts": {
     "biome:check": "biome check .",
+    "check:peer-range": "scripts/check-peer-range.sh",
     "biome:format": "biome format --write .",
     "biome:lint": "biome lint .",
     "db:generate": "turbo run db:generate",

--- a/packages/kysely/CHANGELOG.md
+++ b/packages/kysely/CHANGELOG.md
@@ -5,6 +5,35 @@ Notable changes to `@tsfga/kysely`. The format is based on
 follow [Semantic Versioning](https://semver.org/) (pre-1.0: minor
 releases may contain breaking changes).
 
+## 0.4.1 — 2026-08
+
+### Fixed
+
+- **The peer range on `@tsfga/core` admits 0.5.x.** 0.4.0
+  published `"@tsfga/core": "^0.4.0"`, which below 1.0.0 means
+  `>=0.4.0 <0.5.0` — so installing core 0.5.0 alongside it
+  raised a peer conflict even though nothing in the adapter
+  changed. The range is now `>=0.4.0 <0.6.0`.
+
+  The adapter needs no change to work with core 0.5.0: that
+  release added `checkMany` and shared one resolution scope
+  across a batch, but did not touch the `TupleStore` interface.
+  A batch reaches the adapter as the same `findCheckTuples`,
+  `findTuplesByRelation` and `findRelationConfig` calls a
+  sequence of `check` calls would make — fewer of them, because
+  the memo and the config cache now span the batch.
+
+  One consequence worth knowing if you instrument the store:
+  core 0.5.0 stops abandoned branches from querying, but a read
+  already handed to the adapter still completes. Drain your
+  counters before reading them.
+
+  The range is now hand-written in `package.json` instead of
+  derived from the core version at publish time, and
+  `scripts/check-peer-range.sh` fails CI when a core bump leaves
+  it behind. It required no `@tsfga/kysely` API change, hence a
+  patch release.
+
 ## 0.4.0 — 2026-08
 
 ### Breaking changes

--- a/packages/kysely/README.md
+++ b/packages/kysely/README.md
@@ -13,6 +13,14 @@ the `TupleStore` interface from `@tsfga/core` using
 npm install @tsfga/kysely @tsfga/core kysely pg
 ```
 
+`@tsfga/core`, `kysely` and `pg` are peer dependencies. This
+version accepts `@tsfga/core` `>=0.4.0 <0.6.0` — the adapter
+implements the `TupleStore` interface as those releases shape
+it. The range carries an explicit ceiling rather than a caret:
+below 1.0.0 a core minor may change that interface, so each
+minor is admitted only once the adapter has been tested
+against it.
+
 ## Quick start
 
 ```typescript

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsfga/kysely",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "author": "Lemuel Roberto Bonifacio <code@lemuelroberto.online>",
   "description": "Kysely/PostgreSQL adapter for @tsfga/core",
@@ -55,7 +55,7 @@
     "tsc": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@tsfga/core": "workspace:*",
+    "@tsfga/core": ">=0.4.0 <0.6.0",
     "kysely": ">=0.27.0 <0.30.0",
     "pg": ">=8.0.0"
   },

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -53,3 +53,13 @@ if [ -f "$lockfile" ]; then
 fi
 
 echo "${current} → ${next}"
+
+# Bumping core past the adapter's declared peer ceiling is the
+# mistake this catches at the moment it is made, rather than in
+# CI or -- as it once did -- on npm. Advisory here: reshaping the
+# range is a judgement call, and the bump itself is already done.
+if ! "$(dirname "$0")/check-peer-range.sh"; then
+  echo
+  echo "warning: @tsfga/kysely's peer range no longer matches" \
+    "@tsfga/core. Fix it in this same change."
+fi

--- a/scripts/check-peer-range.sh
+++ b/scripts/check-peer-range.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Assert that @tsfga/kysely's declared peer range on
+# @tsfga/core admits the version of @tsfga/core in this repo.
+#
+# Why this exists: the range used to be "workspace:*", which the
+# release workflow rewrote to "^<core version>" at publish time.
+# Below 1.0.0, caret pins a single minor -- "^0.4.0" means
+# ">=0.4.0 <0.5.0" -- so publishing core 0.5.0 orphaned the last
+# published adapter without any step failing. Nobody was ever
+# asked whether the adapter still worked with the new core,
+# because no human wrote the range down.
+#
+# So the range is hand-written in package.json now, and this
+# check runs in CI: bumping core past the declared ceiling turns
+# into a red build on the bump PR, and the fix is a deliberate
+# decision -- widen the ceiling if the adapter still works,
+# raise the floor if it does not.
+#
+# The range must be spelled ">=A.B.C <D.E.F". An explicit
+# ceiling is the point: "^" and "~" change meaning at 1.0.0,
+# which is precisely the trap this guards.
+#
+# Usage: scripts/check-peer-range.sh
+# Requires: jq
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+core_json="${root}/packages/core/package.json"
+kysely_json="${root}/packages/kysely/package.json"
+
+core_ver=$(jq -r .version "$core_json")
+range=$(jq -r '.peerDependencies["@tsfga/core"]' "$kysely_json")
+dev=$(jq -r '.devDependencies["@tsfga/core"]' "$kysely_json")
+
+fail() {
+  echo "::error::$1"
+  echo "  @tsfga/core version:     ${core_ver}"
+  echo "  @tsfga/kysely peer range: ${range}"
+  exit 1
+}
+
+# Local resolution comes from the devDependency, so the peer
+# range is free to be a published range rather than a workspace
+# link. If the devDependency stops being the link, the adapter
+# starts type-checking against a registry copy of core instead
+# of the source next to it.
+if [ "$dev" != "workspace:*" ]; then
+  fail "packages/kysely devDependency on @tsfga/core must stay
+  \"workspace:*\" (found \"${dev}\"), or the adapter no longer
+  builds against the core in this repo."
+fi
+
+pattern='^>=([0-9]+\.[0-9]+\.[0-9]+) <([0-9]+\.[0-9]+\.[0-9]+)$'
+if [[ ! "$range" =~ $pattern ]]; then
+  fail "peer range must be spelled \">=A.B.C <D.E.F\" with an
+  explicit ceiling. Caret and tilde ranges are rejected because
+  their meaning changes at 1.0.0."
+fi
+
+floor="${BASH_REMATCH[1]}"
+ceiling="${BASH_REMATCH[2]}"
+
+# sort -V orders versions; the lowest of a pair tells us which
+# side of the comparison the core version falls on.
+lowest() { printf '%s\n%s\n' "$1" "$2" | sort -V | head -n 1; }
+
+if [ "$(lowest "$core_ver" "$floor")" != "$floor" ]; then
+  fail "@tsfga/core ${core_ver} is below the declared floor
+  ${floor}. Lower the floor, or bump core."
+fi
+
+if [ "$core_ver" = "$ceiling" ] \
+  || [ "$(lowest "$core_ver" "$ceiling")" = "$ceiling" ]; then
+  fail "@tsfga/core ${core_ver} is at or above the declared
+  ceiling ${ceiling}, so @tsfga/kysely would publish a peer
+  range that excludes the core it was built and tested against.
+  Decide explicitly: widen the ceiling in
+  packages/kysely/package.json if the adapter still works with
+  core ${core_ver}, or raise the floor if this core requires
+  adapter changes. Either way, bump @tsfga/kysely and record it
+  in its CHANGELOG."
+fi
+
+echo "@tsfga/kysely peer range ${range} admits @tsfga/core" \
+  "${core_ver}."


### PR DESCRIPTION
## Summary

- **`@tsfga/kysely@0.4.0` cannot be installed beside `@tsfga/core@0.5.0`.**
  It published `peerDependencies: { "@tsfga/core": "^0.4.0" }`, and below
  1.0.0 caret pins a single minor — so the range means `>=0.4.0 <0.5.0`
  and npm fails with `ERESOLVE ... peer @tsfga/core@"^0.4.0" from
  @tsfga/kysely@0.4.0`. Nothing in the adapter warranted that: core 0.5.0
  added `checkMany` and a shared resolution scope, but did not touch
  `TupleStore`.

- **The range was never written by a person.** `package.json` said
  `workspace:*`, and both `ci.yml` and `release.yml` substituted
  `^$core_ver` for it at publish time, so every core minor silently
  orphaned the last published adapter and no step failed. It is
  hand-written now and ships verbatim; only the `devDependency` is
  substituted, and it stays a workspace link so the adapter still builds
  against the core beside it.

- **Widened to `>=0.4.0 <0.6.0`, released as `@tsfga/kysely@0.4.1`** — no
  adapter change was needed, hence a patch. The explicit ceiling is
  deliberate: below 1.0.0 a core minor may reshape `TupleStore`, so each
  minor is admitted only once the adapter has been tested against it.

- **`scripts/check-peer-range.sh` keeps it from recurring.** It asserts
  core's version falls inside the declared range and rejects caret/tilde
  outright, since their meaning changes at 1.0.0. It runs in CI's lint job
  and again in release before publish, so a core bump that outgrows the
  range is a red build on the bump PR rather than a broken install on npm.
  `bump.sh` warns at the moment the mistake is made, and CLAUDE.md carries
  the decision rule for the next core minor.

## Test plan

- [x] `bun run biome:check`, `bun run tsc`, `bun run turbo:test` — 648
      tests pass (223 core, 58 kysely, 367 conformance)
- [x] Guard rejects all three failure modes: core above the ceiling, core
      below the floor, and a caret range
- [x] Packaging checks against the manifest that actually ships —
      `publint` clean, `attw --profile esm-only` clean, `npm pack` clean
- [x] Packed the 0.4.1 tarball and installed it beside `@tsfga/core@0.5.0`
      in a scratch project — resolves cleanly
- [x] Reproduced the failure: published `@tsfga/kysely@0.4.0` +
      `@tsfga/core@0.5.0` still `ERESOLVE`s
- [x] Full CI green on the fork (11/11 jobs); `commitlint` validated
      locally at 0 problems

## Notes

- Core 0.5.0 is already on npm, so only the `@tsfga/kysely` release
  dispatch remains.
- `examples/node-kysely` still pins `0.3.0` for both packages. Left alone
  since Renovate manages example dependencies, but it needs the same bump
  to exercise 0.5.0.